### PR TITLE
Open source docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.4] - TBD
+### Updated
+- First release: only producing one docker image per application with version tag.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
                   -Dresume=false \
                   -DreleaseVersion=${RELEASE_VERSION} \
                   -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
-                  -DautoVersionSubmodules=true"""{
+                  -DautoVersionSubmodules=true"""
         }
         echo 'Pushing images...'
         docker tag $DOCKER_ORG/beekeeper-cleanup:${RELEASE_VERSION} $DOCKER_ORG/beekeeper-cleanup:latest

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,8 +49,8 @@ pipeline {
         withCredentials([usernamePassword(credentialsId: 'dockerhub-egopensource', passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME')]) {
           docker login -u $USERNAME -p $PASSWORD
         }
-        // docker push $DOCKER_ORG/beekeeper-cleanup
-        // docker push $DOCKER_ORG/beekeeper-path-scheduler-apiary
+        // docker push ${DOCKER_ORG}/beekeeper-cleanup
+        // docker push ${DOCKER_ORG}/beekeeper-path-scheduler-apiary
       }
     }
 
@@ -85,10 +85,10 @@ pipeline {
                   --settings $MAVEN_SETTINGS"""
         }
         echo 'Pushing images...'
-        docker tag $DOCKER_ORG/beekeeper-cleanup:${RELEASE_VERSION} $DOCKER_ORG/beekeeper-cleanup:latest
-        docker tag $DOCKER_ORG/beekeeper-path-scheduler-apiary:${RELEASE_VERSION} $DOCKER_ORG/beekeeper-path-scheduler-apiary:latest
-        docker push $DOCKER_ORG/beekeeper-cleanup
-        docker push $DOCKER_ORG/beekeeper-path-scheduler-apiary
+        docker tag ${DOCKER_ORG}/beekeeper-cleanup:${RELEASE_VERSION} ${DOCKER_ORG}/beekeeper-cleanup:latest
+        docker tag ${DOCKER_ORG}/beekeeper-path-scheduler-apiary:${RELEASE_VERSION} ${DOCKER_ORG}/beekeeper-path-scheduler-apiary:latest
+        docker push ${DOCKER_ORG}/beekeeper-cleanup
+        docker push ${DOCKER_ORG}/beekeeper-path-scheduler-apiary
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     GIT_USERNAME = "${env.GIT_USR}"
     GIT_PASSWORD = "${env.GIT_PSW}"
 
-    DOCKER_ORG = readMavenPom().properties['docker.org']
+    DOCKER_ORG = readMavenPom().getProperties().getProperty('docker.org')
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   }
 
   environment {
-    GIT = credentials('s-hcom-jenkins-rbac')
+    GIT = credentials('s-hcom-ci')
     GIT_USERNAME = "${env.GIT_USR}"
     GIT_PASSWORD = "${env.GIT_PSW}"
 
@@ -22,7 +22,7 @@ pipeline {
         echo 'Checking out project...'
         checkout scm
         echo 'Building...'
-        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'hcomdata-artifactory-maven-settings') {
+        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'hcomdata-oss-settings') {
           sh 'mvn clean deploy jacoco:report checkstyle:checkstyle spotbugs:spotbugs'
         }
         jacoco()
@@ -31,8 +31,8 @@ pipeline {
             tools: [checkStyle(reportEncoding: 'UTF-8'), spotbugs()]
         )
         echo 'Pushing images...'
-        withCredentials([usernamePassword(credentialsId: '', passwordVariable: 'DOCKER_PASSWORD', usernameVariable: 'DOCKER_USERNAME')]) {
-          docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+        withCredentials([usernamePassword(credentialsId: 'dockerhub-egopensource', passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME')]) {
+          docker login -u $USERNAME -p $PASSWORD
         }
         docker push $DOCKER_ORG/beekeeper-cleanup
         docker push $DOCKER_ORG/beekeeper-path-scheduler-apiary
@@ -61,7 +61,7 @@ pipeline {
           }
         }
         echo 'Performing release...'
-        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'hcomdata-artifactory-maven-settings') {
+        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'hcomdata-oss-settings') {
           sh """mvn --batch-mode release:prepare release:perform \
                   -Dresume=false \
                   -DreleaseVersion=${RELEASE_VERSION} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,8 @@ pipeline {
     GIT_USERNAME = "${env.GIT_USR}"
     GIT_PASSWORD = "${env.GIT_PSW}"
 
+    DOCKER_ORG = readMavenPom().getProperties().getProperty('docker.org')
+
     withCredentials([file(credentialsId: 'eg-oss-settings.xml', variable: 'SETTINGS')]) {
       MAVEN_SETTINGS = SETTINGS
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,8 +22,7 @@ pipeline {
     OSS_GPG_SEC_KEYRING = credentials('secring.gpg')
     OSS_GPG_PASSPHRASE = credentials('private-key-passphrase')
 
-    pom = readMavenPom file: 'pom.xml'
-    PROJECT_VERSION = pom.version
+    PROJECT_VERSION = readMavenPom().getVersion()
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   }
 
   environment {
-    GIT = credentials('s-hcom-ci')
+    GIT = credentials('eg-oss-ci')
     GIT_USERNAME = "${env.GIT_USR}"
     GIT_PASSWORD = "${env.GIT_PSW}"
 
@@ -22,7 +22,7 @@ pipeline {
         echo 'Checking out project...'
         checkout scm
         echo 'Building...'
-        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'hcomdata-oss-settings') {
+        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'eg-oss-settings') {
           sh 'mvn clean deploy jacoco:report checkstyle:checkstyle spotbugs:spotbugs'
         }
         jacoco()
@@ -61,7 +61,7 @@ pipeline {
           }
         }
         echo 'Performing release...'
-        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'hcomdata-oss-settings') {
+        withMaven(jdk: 'OpenJDK11', maven: 'Maven3.6', mavenSettingsConfig: 'eg-oss-settings') {
           sh """mvn --batch-mode release:prepare release:perform \
                   -Dresume=false \
                   -DreleaseVersion=${RELEASE_VERSION} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
         }
         echo 'Pushing images...'
         docker tag $DOCKER_ORG/beekeeper-cleanup:${RELEASE_VERSION} $DOCKER_ORG/beekeeper-cleanup:latest
-        docker tag $DOCKER_ORG/beekeeper-path-scheduler-apiary:${RELEASE_VERSION} $DOCKER_ORG/beekeeper-cleanup:latest
+        docker tag $DOCKER_ORG/beekeeper-path-scheduler-apiary:${RELEASE_VERSION} $DOCKER_ORG/beekeeper-path-scheduler-apiary:latest
         docker push $DOCKER_ORG/beekeeper-cleanup
         docker push $DOCKER_ORG/beekeeper-path-scheduler-apiary
       }

--- a/beekeeper-package/beekeeper-assembly-cleanup/pom.xml
+++ b/beekeeper-package/beekeeper-assembly-cleanup/pom.xml
@@ -68,7 +68,7 @@
         </executions>
         <configuration>
           <dockerfile>${dockerfile.path}</dockerfile>
-          <repository>${docker.repo}/beekeeper-cleanup</repository>
+          <repository>${docker.org}/beekeeper-cleanup</repository>
           <buildArgs>
             <BEEKEEPER_VERSION>${project.version}</BEEKEEPER_VERSION>
             <PORT>${docker.port}</PORT>

--- a/beekeeper-package/beekeeper-assembly-cleanup/pom.xml
+++ b/beekeeper-package/beekeeper-assembly-cleanup/pom.xml
@@ -13,6 +13,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <docker.port>8008</docker.port>
     <dockerfile-maven-plugin.version>1.4.10</dockerfile-maven-plugin.version>
   </properties>
 
@@ -54,24 +55,11 @@
         <version>${dockerfile-maven-plugin.version}</version>
         <executions>
           <execution>
-            <id>tag-cleanup-latest</id>
-            <phase>deploy</phase>
+            <id>tag-cleanup</id>
+            <phase>package</phase>
             <goals>
               <goal>build</goal>
               <goal>tag</goal>
-              <goal>push</goal>
-            </goals>
-            <configuration>
-              <tag>latest</tag>
-            </configuration>
-          </execution>
-          <execution>
-            <id>tag-cleanup-version</id>
-            <phase>deploy</phase>
-            <goals>
-              <goal>build</goal>
-              <goal>tag</goal>
-              <goal>push</goal>
             </goals>
             <configuration>
               <tag>${project.version}</tag>
@@ -79,11 +67,11 @@
           </execution>
         </executions>
         <configuration>
-          <dockerfile>src/main/docker/Dockerfile</dockerfile>
+          <dockerfile>${dockerfile.path}</dockerfile>
           <repository>${docker.repo}/beekeeper-cleanup</repository>
           <buildArgs>
             <BEEKEEPER_VERSION>${project.version}</BEEKEEPER_VERSION>
-            <PORT>8008</PORT>
+            <PORT>${docker.port}</PORT>
           </buildArgs>
           <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
         </configuration>

--- a/beekeeper-package/beekeeper-assembly-cleanup/pom.xml
+++ b/beekeeper-package/beekeeper-assembly-cleanup/pom.xml
@@ -56,7 +56,7 @@
         <executions>
           <execution>
             <id>tag-cleanup</id>
-            <phase>package</phase>
+            <phase>deploy</phase>
             <goals>
               <goal>build</goal>
               <goal>tag</goal>

--- a/beekeeper-package/beekeeper-assembly-path-scheduler-apiary/pom.xml
+++ b/beekeeper-package/beekeeper-assembly-path-scheduler-apiary/pom.xml
@@ -68,7 +68,7 @@
         </executions>
         <configuration>
           <dockerfile>${dockerfile.path}</dockerfile>
-          <repository>${docker.repo}/beekeeper-path-scheduler-apiary</repository>
+          <repository>${docker.org}/beekeeper-path-scheduler-apiary</repository>
           <buildArgs>
             <BEEKEEPER_VERSION>${project.version}</BEEKEEPER_VERSION>
             <PORT>${docker.port}</PORT>

--- a/beekeeper-package/beekeeper-assembly-path-scheduler-apiary/pom.xml
+++ b/beekeeper-package/beekeeper-assembly-path-scheduler-apiary/pom.xml
@@ -13,6 +13,7 @@
   <packaging>pom</packaging>
 
   <properties>
+    <docker.port>8080</docker.port>
     <dockerfile-maven-plugin.version>1.4.10</dockerfile-maven-plugin.version>
   </properties>
 
@@ -54,24 +55,11 @@
         <version>${dockerfile-maven-plugin.version}</version>
         <executions>
           <execution>
-            <id>tag-path-scheduler-apiary-latest</id>
-            <phase>deploy</phase>
+            <id>tag-path-scheduler-apiary</id>
+            <phase>package</phase>
             <goals>
               <goal>build</goal>
               <goal>tag</goal>
-              <goal>push</goal>
-            </goals>
-            <configuration>
-              <tag>latest</tag>
-            </configuration>
-          </execution>
-          <execution>
-            <id>tag-path-scheduler-apiary-version</id>
-            <phase>deploy</phase>
-            <goals>
-              <goal>build</goal>
-              <goal>tag</goal>
-              <goal>push</goal>
             </goals>
             <configuration>
               <tag>${project.version}</tag>
@@ -79,11 +67,11 @@
           </execution>
         </executions>
         <configuration>
-          <dockerfile>src/main/docker/Dockerfile</dockerfile>
+          <dockerfile>${dockerfile.path}</dockerfile>
           <repository>${docker.repo}/beekeeper-path-scheduler-apiary</repository>
           <buildArgs>
             <BEEKEEPER_VERSION>${project.version}</BEEKEEPER_VERSION>
-            <PORT>8080</PORT>
+            <PORT>${docker.port}</PORT>
           </buildArgs>
           <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
         </configuration>

--- a/beekeeper-package/beekeeper-assembly-path-scheduler-apiary/pom.xml
+++ b/beekeeper-package/beekeeper-assembly-path-scheduler-apiary/pom.xml
@@ -56,7 +56,7 @@
         <executions>
           <execution>
             <id>tag-path-scheduler-apiary</id>
-            <phase>package</phase>
+            <phase>deploy</phase>
             <goals>
               <goal>build</goal>
               <goal>tag</goal>

--- a/beekeeper-package/pom.xml
+++ b/beekeeper-package/pom.xml
@@ -17,28 +17,9 @@
     <module>beekeeper-assembly-path-scheduler-apiary</module>
   </modules>
 
-  <profiles>
-    <profile>
-      <id>snapshot-profile</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <docker.repo>${artifactory.docker.snapshot.repository.id}.${artifactory.base}</docker.repo>
-      </properties>
-    </profile>
-    <profile>
-      <id>release-profile</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
-      <properties>
-        <docker.repo>${artifactory.docker.release.repository.id}.${artifactory.base}</docker.repo>
-      </properties>
-    </profile>
-  </profiles>
+  <properties>
+    <docker.repo></docker.repo>
+    <dockerfile.path>src/main/docker/Dockerfile</dockerfile.path>
+  </properties>
 
 </project>

--- a/beekeeper-package/pom.xml
+++ b/beekeeper-package/pom.xml
@@ -18,6 +18,7 @@
   </modules>
 
   <properties>
+    <docker.org>expediagroup</docker.org>
     <dockerfile.path>src/main/docker/Dockerfile</dockerfile.path>
   </properties>
 

--- a/beekeeper-package/pom.xml
+++ b/beekeeper-package/pom.xml
@@ -18,7 +18,7 @@
   </modules>
 
   <properties>
-    <docker.repo></docker.repo>
+    <docker.org></docker.org>
     <dockerfile.path>src/main/docker/Dockerfile</dockerfile.path>
   </properties>
 

--- a/beekeeper-package/pom.xml
+++ b/beekeeper-package/pom.xml
@@ -18,7 +18,6 @@
   </modules>
 
   <properties>
-    <docker.org></docker.org>
     <dockerfile.path>src/main/docker/Dockerfile</dockerfile.path>
   </properties>
 


### PR DESCRIPTION
Updating build to only produce one, versioned image per application and not push. Updating Jenkinsfile to push images on deploys and tag as latest on release. This presumes that snapshot/release images will be in the same repo.

Still required:
- `eg-oss-ci` user
- `eg-oss-settings`
- `docker.hub` property in `eg-oss-parent`
- Test that `DOCKER_ORG = readMavenPom().properties['docker.org']` works as expected
