### PR TITLE
Removing old test

### DIFF
--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3Client.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3Client.java
@@ -69,7 +69,7 @@ public class S3Client {
       return keyVersions
           .stream()
           .map(DeleteObjectsRequest.KeyVersion::getKey)
-          .peek(key -> log.info("Dry run - deleting up \"{}/{}\"", bucket, key))
+          .peek(key -> log.info("Dry run - deleting \"{}/{}\"", bucket, key))
           .collect(Collectors.toList());
     }
   }


### PR DESCRIPTION
I can't get this test to fail locally, but it has broken the Jenkins build twice consecutively.

Seeing as we aren't using gauge metrics anymore, we might as well remove it.

I think what's happening is that both paths are deleted and so the metric reported is `CONTENT.getBytes().length + doubleContent.getBytes().length` which fails on the assert at line 253. Perhaps our machines are fast enough in this loop to catch the metric before the second path is deleted.

Any thoughts?
