### PR TITLE
Handle hadoop s3 uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.6] - 2019-11-26
+### Changed
+- Handling cleanup for `s3a` and `s3n` paths.
+
 ## [1.1.5] - 2019-11-18
 ### Changed
 - Using default deletion delay if table parameter is configured incorrectly.

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleaner.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleaner.java
@@ -50,9 +50,9 @@ public class S3PathCleaner implements PathCleaner {
   @Override
   @Timed("s3-paths-deleted")
   public void cleanupPath(String housekeepingPath, String tableName) {
-    S3SchemeURI s3URI = extractURI(housekeepingPath);
-    String key = s3URI.getKey();
-    String bucket = s3URI.getBucket();
+    S3SchemeURI s3SchemeURI = extractURI(housekeepingPath);
+    String key = s3SchemeURI.getKey();
+    String bucket = s3SchemeURI.getBucket();
 
     // doesObjectExists returns true only when the key is a file
     boolean isFile = s3Client.doesObjectExist(bucket, key);
@@ -81,13 +81,13 @@ public class S3PathCleaner implements PathCleaner {
   }
 
   private S3SchemeURI extractURI(String housekeepingPath) {
-    S3SchemeURI s3SchemeUri;
+    S3SchemeURI s3SchemeURI;
     try {
-      s3SchemeUri = new S3SchemeURI(housekeepingPath);
+      s3SchemeURI = new S3SchemeURI(housekeepingPath);
     } catch (Exception e) {
       throw new BeekeeperException(format("Could not create URI from path: '%s'", housekeepingPath), e);
     }
-    return s3SchemeUri;
+    return s3SchemeURI;
   }
 
   private void deleteFilesInDirectory(String bucket, String key) {

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3SchemeURI.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3SchemeURI.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beekeeper.cleanup.path.aws;
+
+import static java.lang.String.format;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import com.amazonaws.services.s3.AmazonS3URI;
+
+import com.expediagroup.beekeeper.core.error.BeekeeperException;
+
+public class S3SchemeURI {
+
+  private AmazonS3URI amazonS3URI;
+
+  public S3SchemeURI(String housekeepingPath) throws URISyntaxException {
+    if (!housekeepingPath.startsWith("s3")) {
+      throw new BeekeeperException(format("'%s' is not an S3 path.", housekeepingPath));
+    }
+    URI uri = URI.create(housekeepingPath);
+    URI s3Uri = new URI("s3", uri.getHost(), uri.getPath(), null);
+    this.amazonS3URI = new AmazonS3URI(s3Uri);
+  }
+
+  public String getKey() {
+    return amazonS3URI.getKey();
+  }
+
+  public String getBucket() {
+    return amazonS3URI.getBucket();
+  }
+
+}

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleanerTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleanerTest.java
@@ -346,4 +346,12 @@ class S3PathCleanerTest {
 
     verifyNoMoreInteractions(mockS3BytesDeletedReporter);
   }
+
+  @Test
+  void extractingURIFails() {
+    String path = "not a real path";
+    assertThatExceptionOfType(BeekeeperException.class)
+      .isThrownBy(() -> s3PathCleaner.cleanupPath(path, tableName))
+      .withMessage(format("Could not create URI from path: '%s'", path));
+  }
 }

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3SchemeURITest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3SchemeURITest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beekeeper.cleanup.path.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.expediagroup.beekeeper.core.error.BeekeeperException;
+
+@ExtendWith(MockitoExtension.class)
+class S3SchemeURITest {
+
+  private static final String BUCKET = "bucket";
+  private static final String KEY = "dir/file";
+  private static final String S3_PATH = "s3://" + BUCKET + "/" + KEY;
+  private static final String S3A_PATH = "s3a://" + BUCKET + "/" + KEY;
+  private static final String S3N_PATH = "s3n://" + BUCKET + "/" + KEY;
+
+  @Test
+  void typicalPath() throws URISyntaxException {
+    S3SchemeURI uri = new S3SchemeURI(S3_PATH);
+    assertThat(uri.getBucket()).isEqualTo(BUCKET);
+    assertThat(uri.getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  void s3aPath() throws URISyntaxException {
+    S3SchemeURI uri = new S3SchemeURI(S3A_PATH);
+    assertThat(uri.getBucket()).isEqualTo(BUCKET);
+    assertThat(uri.getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  void s3nPath() throws URISyntaxException {
+    S3SchemeURI uri = new S3SchemeURI(S3N_PATH);
+    assertThat(uri.getBucket()).isEqualTo(BUCKET);
+    assertThat(uri.getKey()).isEqualTo(KEY);
+  }
+
+  @Test
+  void pathIsNotS3() {
+    assertThatExceptionOfType(BeekeeperException.class)
+      .isThrownBy(() -> new S3SchemeURI("anotherscheme://bucket"))
+      .withMessage("'anotherscheme://bucket' is not an S3 path.");
+  }
+
+}


### PR DESCRIPTION
If the path starts with "s3", this change will ensure that the scheme used for the S3 URI will be "s3" only and not "s3a" or "s3n".