### PR TITLE
Drop table whitelisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.7] - TBD
 ### Adding
 - `TimedTaggable` annotation to time and report table level metrics.
+- `DropTableListenerEventFilter` to filter drop table events unless tagged with `beekeeper.permit.drop.table`.
 
 ## [1.1.6] - 2019-11-27
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Beekeeper only actions on events which are marked with a specific parameter. Thi
 |:----|:----:|:----:|:----|
 | `beekeeper.remove.unreferenced.data=true`   | Yes |  `true` or `false`       | Set this parameter to ensure Beekeeper monitors your table for orphaned data. |
 | `beekeeper.unreferenced.data.retention.period=X` | No | e.g. `P7D` or `PT3H` (based on [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601)) | Set this parameter to control the delay between schedule and deletion by Beekeeper. If this is either not set, or configured incorrectly, the default will be used. Default is 3 days. |
+| `beekeeper.permit.drop.table=true` | No | `true` or `false` | If this parameter is false, or not set, Beekeeper will ignore drop table events. |
 
 This command can be used to add a parameter to a Hive Table:
 

--- a/beekeeper-path-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/context/CommonBeans.java
+++ b/beekeeper-path-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/context/CommonBeans.java
@@ -29,6 +29,7 @@ import org.springframework.retry.annotation.EnableRetry;
 import com.expedia.apiary.extensions.receiver.common.messaging.MessageReader;
 import com.expedia.apiary.extensions.receiver.sqs.messaging.SqsMessageReader;
 
+import com.expediagroup.beekeeper.scheduler.apiary.filter.DropTableListenerEventFilter;
 import com.expediagroup.beekeeper.scheduler.apiary.filter.EventTypeListenerEventFilter;
 import com.expediagroup.beekeeper.scheduler.apiary.filter.ListenerEventFilter;
 import com.expediagroup.beekeeper.scheduler.apiary.filter.MetadataOnlyListenerEventFilter;
@@ -62,8 +63,10 @@ public class CommonBeans {
   @Bean(name = "filteringMessageReader")
   MessageReader filteringMessageReader(@Qualifier("retryingMessageReader") MessageReader messageReader,
     TableParameterListenerEventFilter tableParameterFilter, EventTypeListenerEventFilter eventTypeFilter,
-    MetadataOnlyListenerEventFilter metadataOnlyListenerEventFilter) {
-    List<ListenerEventFilter> filters = List.of(eventTypeFilter, tableParameterFilter, metadataOnlyListenerEventFilter);
+    MetadataOnlyListenerEventFilter metadataOnlyListenerEventFilter,
+    DropTableListenerEventFilter dropTableListenerEventFilter) {
+    List<ListenerEventFilter> filters = List.of(eventTypeFilter, tableParameterFilter,
+      metadataOnlyListenerEventFilter, dropTableListenerEventFilter);
     return new FilteringMessageReader(messageReader, filters);
   }
 

--- a/beekeeper-path-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/filter/DropTableListenerEventFilter.java
+++ b/beekeeper-path-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/filter/DropTableListenerEventFilter.java
@@ -19,22 +19,27 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import com.expedia.apiary.extensions.receiver.common.event.DropTableEvent;
 import com.expedia.apiary.extensions.receiver.common.event.ListenerEvent;
 
 @Component
-public class TableParameterListenerEventFilter implements ListenerEventFilter {
+public class DropTableListenerEventFilter implements ListenerEventFilter {
 
-  private static final String BEEKEEPER_TABLE_PARAMETER = "beekeeper.remove.unreferenced.data";
+  private static final String DROP_TABLE_WHITELIST_PARAMETER = "beekeeper.permit.drop.table";
 
   @Override
   public boolean filter(ListenerEvent listenerEvent) {
     if (listenerEvent == null) {
       return true;
     }
+    Class<? extends ListenerEvent> eventClass = listenerEvent.getEventType().eventClass();
+    if (!DropTableEvent.class.equals(eventClass)) {
+      return false;
+    }
     Map<String, String> tableParameters = listenerEvent.getTableParameters();
     if (tableParameters == null) {
       return true;
     }
-    return !Boolean.valueOf(tableParameters.get(BEEKEEPER_TABLE_PARAMETER));
+    return !Boolean.valueOf(tableParameters.get(DROP_TABLE_WHITELIST_PARAMETER));
   }
 }

--- a/beekeeper-path-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/filter/MetadataOnlyListenerEventFilter.java
+++ b/beekeeper-path-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/filter/MetadataOnlyListenerEventFilter.java
@@ -27,6 +27,9 @@ public class MetadataOnlyListenerEventFilter implements ListenerEventFilter {
 
   @Override
   public boolean filter(ListenerEvent listenerEvent) {
+    if (listenerEvent == null) {
+      return true;
+    }
     EventType eventType = listenerEvent.getEventType();
     switch (eventType) {
     case ALTER_PARTITION:

--- a/beekeeper-path-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/filter/DropTableListenerEventFilterTest.java
+++ b/beekeeper-path-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/filter/DropTableListenerEventFilterTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2019 Expedia, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.expediagroup.beekeeper.scheduler.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.expedia.apiary.extensions.receiver.common.event.AddPartitionEvent;
+import com.expedia.apiary.extensions.receiver.common.event.DropTableEvent;
+import com.expedia.apiary.extensions.receiver.common.event.EventType;
+
+import com.expediagroup.beekeeper.scheduler.apiary.filter.DropTableListenerEventFilter;
+
+@ExtendWith(MockitoExtension.class)
+public class DropTableListenerEventFilterTest {
+
+  private static final String BEEKEEPER_WHITELIST_DROP_TABLE = "beekeeper.permit.drop.table";
+  private static final String WHITELISTED = "true";
+  private static final String NOT_WHITELISTED = "false";
+
+  @Mock
+  private AddPartitionEvent addPartitionEvent;
+  @Mock
+  private DropTableEvent dropTableEvent;
+
+  private DropTableListenerEventFilter listenerEventFilter = new DropTableListenerEventFilter();
+
+  @Test
+  public void typicalDoNotFilterWhitelistedDropTableEvent() {
+    when(dropTableEvent.getEventType()).thenReturn(EventType.DROP_TABLE);
+    when(dropTableEvent.getTableParameters())
+      .thenReturn(Map.of(BEEKEEPER_WHITELIST_DROP_TABLE, WHITELISTED));
+    boolean filter = listenerEventFilter.filter(dropTableEvent);
+    assertThat(filter).isFalse();
+  }
+
+  @Test
+  public void filterNonWhitelistedDropTableEvent() {
+    when(dropTableEvent.getEventType()).thenReturn(EventType.DROP_TABLE);
+    when(dropTableEvent.getTableParameters())
+      .thenReturn(Map.of(BEEKEEPER_WHITELIST_DROP_TABLE, NOT_WHITELISTED));
+    boolean filter = listenerEventFilter.filter(dropTableEvent);
+    assertThat(filter).isTrue();
+  }
+
+  @Test
+  public void filterNonWhitelistedDropTableEvent2() {
+    when(dropTableEvent.getEventType()).thenReturn(EventType.DROP_TABLE);
+    boolean filter = listenerEventFilter.filter(dropTableEvent);
+    assertThat(filter).isTrue();
+  }
+
+  @Test
+  public void filterNullTableParametersDropTableEvent() {
+    when(dropTableEvent.getEventType()).thenReturn(EventType.DROP_TABLE);
+    when(dropTableEvent.getTableParameters())
+      .thenReturn(null);
+    boolean filter = listenerEventFilter.filter(dropTableEvent);
+    assertThat(filter).isTrue();
+  }
+
+  @Test
+  public void filterEmptyTableParametersDropTableEvent() {
+    when(dropTableEvent.getEventType()).thenReturn(EventType.DROP_TABLE);
+    when(dropTableEvent.getTableParameters())
+      .thenReturn(Collections.emptyMap());
+    boolean filter = listenerEventFilter.filter(dropTableEvent);
+    assertThat(filter).isTrue();
+  }
+
+  @Test
+  public void doNotFilterNonDropTableEvent() {
+    when(addPartitionEvent.getEventType()).thenReturn(EventType.ADD_PARTITION);
+    boolean filter = listenerEventFilter.filter(addPartitionEvent);
+    assertThat(filter).isFalse();
+  }
+
+  @Test
+  public void filterNullEvent() {
+    boolean filter = listenerEventFilter.filter(null);
+    assertThat(filter).isTrue();
+  }
+}

--- a/beekeeper-path-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/filter/MetadataOnlyListenerEventFilterTest.java
+++ b/beekeeper-path-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/filter/MetadataOnlyListenerEventFilterTest.java
@@ -129,4 +129,10 @@ public class MetadataOnlyListenerEventFilterTest {
     verifyNoMoreInteractions(dropPartitionEvent);
   }
 
+  @Test
+  public void filterNullEvent() {
+    boolean filter = metadataOnlyListenerEventFilter.filter(null);
+    assertThat(filter).isTrue();
+  }
+
 }

--- a/beekeeper-path-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/filter/TableParameterListenerEventFilterTest.java
+++ b/beekeeper-path-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/filter/TableParameterListenerEventFilterTest.java
@@ -81,4 +81,10 @@ public class TableParameterListenerEventFilterTest {
     Boolean filter = listenerEventFilter.filter(alterPartitionEvent);
     assertThat(filter).isTrue();
   }
+
+  @Test
+  public void filterNullEvent() {
+    boolean filter = listenerEventFilter.filter(null);
+    assertThat(filter).isTrue();
+  }
 }


### PR DESCRIPTION
Drop table events will now require a whitelist parameter to be present:

`beekeeper.permit.drop.table=true`

I've also added null checks for the other filters so that the ordering of the filters doesn't matter.