### PR TITLE
Batch delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - TBD
+### Changed
+- `S3Client.listObjects()` to list all objects at a key with batching.  
+
 ## [1.2.0] - 2020-01-06
 ### Adding
 - `TimedTaggable` annotation to time and report table level metrics.

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
@@ -21,8 +21,6 @@ import java.util.Map;
 
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
-import com.expediagroup.beekeeper.core.error.BeekeeperException;
-
 public class S3BytesDeletedCalculator {
 
   private S3Client s3Client;
@@ -34,13 +32,11 @@ public class S3BytesDeletedCalculator {
   }
 
   public void storeFileSize(String bucket, String key) {
-    checkKeysAreEmpty();
     long bytes = s3Client.getObjectMetadata(bucket, key).getContentLength();
     keyToSize.put(key, bytes);
   }
 
   public void storeFileSizes(List<S3ObjectSummary> objectSummaries) {
-    checkKeysAreEmpty();
     objectSummaries.forEach(objectSummary -> {
       long bytes = objectSummary.getSize();
       keyToSize.put(objectSummary.getKey(), bytes);
@@ -59,12 +55,6 @@ public class S3BytesDeletedCalculator {
 
   public long getBytesDeleted() {
     return bytesDeleted;
-  }
-
-  private void checkKeysAreEmpty() {
-    if (!keyToSize.isEmpty()) {
-      throw new BeekeeperException("Should not store file sizes twice.");
-    }
   }
 
 }

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
@@ -33,24 +33,24 @@ public class S3BytesDeletedCalculator {
     this.s3Client = s3Client;
   }
 
-  public void storeFileSizes(String bucket, List<String> keys) {
-    if (!keyToSize.isEmpty()) {
-      throw new BeekeeperException("Should not cache files twice.");
-    }
-    keys.forEach(key -> {
-      long bytes = s3Client.getObjectMetadata(bucket, key).getContentLength();
-      keyToSize.put(key, bytes);
-    });
+  public void storeFileSize(String bucket, String key) {
+    checkKeysAreEmpty();
+    long bytes = s3Client.getObjectMetadata(bucket, key).getContentLength();
+    keyToSize.put(key, bytes);
   }
 
   public void storeFileSizes(List<S3ObjectSummary> objectSummaries) {
-    if (!keyToSize.isEmpty()) {
-      throw new BeekeeperException("Should not cache files twice.");
-    }
+    checkKeysAreEmpty();
     objectSummaries.forEach(objectSummary -> {
       long bytes = objectSummary.getSize();
       keyToSize.put(objectSummary.getKey(), bytes);
     });
+  }
+
+  public void calculateBytesDeleted(String keyDeleted) {
+    if (!keyToSize.isEmpty() && keyToSize.containsKey(keyDeleted)) {
+      bytesDeleted = keyToSize.get(keyDeleted);
+    }
   }
 
   public void calculateBytesDeleted(List<String> keysDeleted) {
@@ -65,6 +65,12 @@ public class S3BytesDeletedCalculator {
 
   public long getBytesDeleted() {
     return bytesDeleted;
+  }
+
+  private void checkKeysAreEmpty() {
+    if (!keyToSize.isEmpty()) {
+      throw new BeekeeperException("Should not store file sizes twice.");
+    }
   }
 
 }

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
@@ -19,6 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
 import com.expediagroup.beekeeper.core.error.BeekeeperException;
 
 public class S3BytesDeletedCalculator {
@@ -38,6 +40,16 @@ public class S3BytesDeletedCalculator {
     keys.forEach(key -> {
       long bytes = s3Client.getObjectMetadata(bucket, key).getContentLength();
       keyToSize.put(key, bytes);
+    });
+  }
+
+  public void storeFileSizes(List<S3ObjectSummary> objectSummaries) {
+    if (!keyToSize.isEmpty()) {
+      throw new BeekeeperException("Should not cache files twice.");
+    }
+    objectSummaries.forEach(objectSummary -> {
+      long bytes = objectSummary.getSize();
+      keyToSize.put(objectSummary.getKey(), bytes);
     });
   }
 

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculator.java
@@ -47,12 +47,6 @@ public class S3BytesDeletedCalculator {
     });
   }
 
-  public void calculateBytesDeleted(String keyDeleted) {
-    if (!keyToSize.isEmpty() && keyToSize.containsKey(keyDeleted)) {
-      bytesDeleted = keyToSize.get(keyDeleted);
-    }
-  }
-
   public void calculateBytesDeleted(List<String> keysDeleted) {
     if (!keyToSize.isEmpty()) {
       keysDeleted.forEach(key -> {

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3Client.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3Client.java
@@ -26,6 +26,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsResult;
 import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
@@ -49,12 +50,17 @@ public class S3Client {
     }
   }
 
-  List<S3ObjectSummary> listObjects(String bucket, String key) {
+  ListObjectsV2Result listObjects(String bucket, String key) {
+    return listBatchObjects(bucket, key, null);
+  }
+
+  ListObjectsV2Result listBatchObjects(String bucket, String key, String continuationToken) {
     ListObjectsV2Request request = new ListObjectsV2Request()
       .withBucketName(bucket)
       .withPrefix(key)
-      .withEncodingType("url");
-    return amazonS3.listObjectsV2(request).getObjectSummaries();
+      .withEncodingType("url")
+      .withContinuationToken(continuationToken);
+    return amazonS3.listObjectsV2(request);
   }
 
   List<String> deleteObjects(String bucket, List<String> keys) {

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleaner.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleaner.java
@@ -17,14 +17,12 @@ package com.expediagroup.beekeeper.cleanup.path.aws;
 
 import static java.lang.String.format;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.base.Strings;
 
@@ -75,9 +73,9 @@ public class S3PathCleaner implements PathCleaner {
   }
 
   private void deleteFile(String bucket, String key, S3BytesDeletedCalculator bytesDeletedCalculator) {
-    bytesDeletedCalculator.storeFileSizes(bucket, List.of(key));
+    bytesDeletedCalculator.storeFileSize(bucket, key);
     s3Client.deleteObject(bucket, key);
-    bytesDeletedCalculator.calculateBytesDeleted(List.of(key));
+    bytesDeletedCalculator.calculateBytesDeleted(key);
   }
 
   private void deleteFilesInDirectory(String bucket, String key, S3BytesDeletedCalculator bytesDeletedCalculator) {

--- a/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleaner.java
+++ b/beekeeper-cleanup/src/main/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleaner.java
@@ -75,7 +75,7 @@ public class S3PathCleaner implements PathCleaner {
   private void deleteFile(String bucket, String key, S3BytesDeletedCalculator bytesDeletedCalculator) {
     bytesDeletedCalculator.storeFileSize(bucket, key);
     s3Client.deleteObject(bucket, key);
-    bytesDeletedCalculator.calculateBytesDeleted(key);
+    bytesDeletedCalculator.calculateBytesDeleted(List.of(key));
   }
 
   private void deleteFilesInDirectory(String bucket, String key, S3BytesDeletedCalculator bytesDeletedCalculator) {

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculatorTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculatorTest.java
@@ -58,7 +58,7 @@ class S3BytesDeletedCalculatorTest {
     objectMetadata.setContentLength(contentBytes);
     when(s3Client.getObjectMetadata(any(), any())).thenReturn(objectMetadata);
     s3BytesDeletedCalculator.storeFileSize(bucket, key1);
-    s3BytesDeletedCalculator.calculateBytesDeleted(key1);
+    s3BytesDeletedCalculator.calculateBytesDeleted(List.of(key1));
     assertThat(s3BytesDeletedCalculator.getBytesDeleted()).isEqualTo(contentBytes);
   }
 
@@ -67,7 +67,7 @@ class S3BytesDeletedCalculatorTest {
     objectMetadata.setContentLength(contentBytes);
     when(s3Client.getObjectMetadata(any(), any())).thenReturn(objectMetadata);
     s3BytesDeletedCalculator.storeFileSize(bucket, key1);
-    s3BytesDeletedCalculator.calculateBytesDeleted(key2);
+    s3BytesDeletedCalculator.calculateBytesDeleted(List.of(key2));
     assertThat(s3BytesDeletedCalculator.getBytesDeleted()).isEqualTo(0);
   }
 

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculatorTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3BytesDeletedCalculatorTest.java
@@ -16,7 +16,6 @@
 package com.expediagroup.beekeeper.cleanup.path.aws;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -33,8 +32,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-
-import com.expediagroup.beekeeper.core.error.BeekeeperException;
 
 @ExtendWith(MockitoExtension.class)
 class S3BytesDeletedCalculatorTest {
@@ -93,24 +90,6 @@ class S3BytesDeletedCalculatorTest {
     s3BytesDeletedCalculator.storeFileSizes(objectSummaries);
     s3BytesDeletedCalculator.calculateBytesDeleted(Collections.emptyList());
     assertThat(s3BytesDeletedCalculator.getBytesDeleted()).isEqualTo(0);
-  }
-
-  @Test
-  void multipleStoreKeySizeThrowsException() {
-    objectMetadata.setContentLength(contentBytes);
-    when(s3Client.getObjectMetadata(any(), any())).thenReturn(objectMetadata);
-    s3BytesDeletedCalculator.storeFileSize(bucket, key1);
-    assertThatThrownBy(() -> s3BytesDeletedCalculator.storeFileSize(bucket, key1))
-      .isInstanceOf(BeekeeperException.class)
-      .hasMessage("Should not store file sizes twice.");
-  }
-
-  @Test
-  void multipleStoreObjectSummarySizeThrowsException() {
-    s3BytesDeletedCalculator.storeFileSizes(objectSummaries(key1, key2, key3));
-    assertThatThrownBy(() -> s3BytesDeletedCalculator.storeFileSizes(objectSummaries(key1, key2, key3)))
-      .isInstanceOf(BeekeeperException.class)
-      .hasMessage("Should not store file sizes twice.");
   }
 
   private List<S3ObjectSummary> objectSummaries(String... keys) {

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3ClientTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3ClientTest.java
@@ -18,6 +18,7 @@ package com.expediagroup.beekeeper.cleanup.path.aws;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -106,7 +107,7 @@ class S3ClientTest {
     amazonS3.putObject(bucket, key1, content);
     amazonS3.putObject(bucket, key2, content);
 
-    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot).getObjectSummaries();
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot);
 
     assertThat(result.size()).isEqualTo(2);
     assertThat(result.get(0).getBucketName()).isEqualTo(bucket);
@@ -122,7 +123,7 @@ class S3ClientTest {
     amazonS3.putObject(bucket, spacedKey1, content);
     amazonS3.putObject(bucket, spacedKey2, content);
 
-    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot).getObjectSummaries();
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot);
 
     assertThat(result.size()).isEqualTo(2);
     assertThat(result.get(0).getBucketName()).isEqualTo(bucket);
@@ -139,13 +140,29 @@ class S3ClientTest {
     amazonS3.putObject(bucket, spacedKey1, content);
     amazonS3.putObject(bucket, spacedKey2, content);
 
-    List<S3ObjectSummary> result = s3Client.listObjects(bucket, spacedKeyRoot).getObjectSummaries();
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, spacedKeyRoot);
 
     assertThat(result.size()).isEqualTo(2);
     assertThat(result.get(0).getBucketName()).isEqualTo(bucket);
     assertThat(result.get(0).getKey()).isEqualTo(spacedKey1);
     assertThat(result.get(1).getBucketName()).isEqualTo(bucket);
     assertThat(result.get(1).getKey()).isEqualTo(spacedKey2);
+  }
+
+  @Test
+  void listBatchObjects() {
+    int s3BatchSize = 1000;
+    int extraKeys = 100;
+    List<String> keys = new ArrayList<>();
+    for (int i = 1; i <= s3BatchSize + extraKeys; i++) {
+      keys.add(keyRoot + "/file" + i);
+    }
+    keys.parallelStream()
+      .forEach(key -> amazonS3.putObject(bucket, key, content));
+
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot);
+
+    assertThat(result.size()).isEqualTo(s3BatchSize + extraKeys);
   }
 
   @Test

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3ClientTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3ClientTest.java
@@ -106,7 +106,7 @@ class S3ClientTest {
     amazonS3.putObject(bucket, key1, content);
     amazonS3.putObject(bucket, key2, content);
 
-    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot);
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot).getObjectSummaries();
 
     assertThat(result.size()).isEqualTo(2);
     assertThat(result.get(0).getBucketName()).isEqualTo(bucket);
@@ -122,7 +122,7 @@ class S3ClientTest {
     amazonS3.putObject(bucket, spacedKey1, content);
     amazonS3.putObject(bucket, spacedKey2, content);
 
-    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot);
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, keyRoot).getObjectSummaries();
 
     assertThat(result.size()).isEqualTo(2);
     assertThat(result.get(0).getBucketName()).isEqualTo(bucket);
@@ -139,7 +139,7 @@ class S3ClientTest {
     amazonS3.putObject(bucket, spacedKey1, content);
     amazonS3.putObject(bucket, spacedKey2, content);
 
-    List<S3ObjectSummary> result = s3Client.listObjects(bucket, spacedKeyRoot);
+    List<S3ObjectSummary> result = s3Client.listObjects(bucket, spacedKeyRoot).getObjectSummaries();
 
     assertThat(result.size()).isEqualTo(2);
     assertThat(result.get(0).getBucketName()).isEqualTo(bucket);

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3ClientTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3ClientTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,6 +31,9 @@ import org.mockito.Mockito;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 
@@ -57,11 +61,28 @@ class S3ClientTest {
   void setUp() {
     amazonS3 = AmazonS3Factory.newInstance(s3Container);
     amazonS3.createBucket(bucket);
-    amazonS3.listObjectsV2(bucket)
-      .getObjectSummaries()
-      .forEach(object -> amazonS3.deleteObject(bucket, object.getKey()));
+    emptyBucket(bucket);
+    assertThat(amazonS3.listObjectsV2(bucket).getObjectSummaries()).isEmpty();
     s3Client = new S3Client(amazonS3, false);
     s3ClientDryRun = new S3Client(amazonS3, true);
+  }
+
+  private void emptyBucket(String bucket) {
+    ListObjectsV2Result listObjectsV2Result;
+    String continuationToken = null;
+    do {
+      ListObjectsV2Request request = new ListObjectsV2Request()
+        .withBucketName(bucket)
+        .withContinuationToken(continuationToken);
+      listObjectsV2Result = amazonS3.listObjectsV2(request);
+      DeleteObjectsRequest deleteObjectsRequest = new DeleteObjectsRequest(bucket);
+      List<String> keys = listObjectsV2Result.getObjectSummaries()
+        .stream()
+        .map(S3ObjectSummary::getKey)
+        .collect(Collectors.toList());
+      amazonS3.deleteObjects(deleteObjectsRequest.withKeys(keys.toArray(new String[]{})));
+      continuationToken = listObjectsV2Result.getNextContinuationToken();
+    } while (listObjectsV2Result.isTruncated());
   }
 
   @AfterAll

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleanerTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleanerTest.java
@@ -385,7 +385,8 @@ class S3PathCleanerTest {
     S3ObjectSummary s3ObjectSummary2 = new S3ObjectSummary();
     s3ObjectSummary2.setBucketName(bucket);
     s3ObjectSummary2.setKey(key2);
-    when(mockS3Client.listObjects(bucket, keyRoot + "/")).thenReturn(List.of(s3ObjectSummary, s3ObjectSummary2));
+//    when(mockS3Client.listObjects(bucket, keyRoot + "/")).thenReturn(listObjectsV2Resultist.of(s3ObjectSummary
+//      , s3ObjectSummary2));
     int bytes = 10;
     ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentLength(bytes);

--- a/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleanerTest.java
+++ b/beekeeper-cleanup/src/test/java/com/expediagroup/beekeeper/cleanup/path/aws/S3PathCleanerTest.java
@@ -29,8 +29,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
@@ -256,42 +254,6 @@ class S3PathCleanerTest {
   }
 
   @Test
-  void notAllObjectsDeleted() {
-    AmazonS3 mockAmazonS3 = mock(AmazonS3.class);
-    S3Client mockS3Client = new S3Client(mockAmazonS3, false);
-    mockOneOutOfTwoObjectsDeleted(mockAmazonS3, keyRootAsDirectory);
-
-    s3PathCleaner = new S3PathCleaner(mockS3Client, s3SentinelFilesCleaner, bytesDeletedReporter);
-    assertThatExceptionOfType(BeekeeperException.class)
-        .isThrownBy(() -> s3PathCleaner.cleanupPath(housekeepingPath))
-        .withMessage(format("Not all files could be deleted at path \"%s/%s\"; deleted 1/2 objects. "
-            + "Objects not deleted: 'table/id1/partition_1/file2'.", bucket,
-            keyRootAsDirectory));
-  }
-
-  private void mockOneOutOfTwoObjectsDeleted(AmazonS3 mockAmazonS3, String key) {
-    S3ObjectSummary s3ObjectSummary1 = new S3ObjectSummary();
-    S3ObjectSummary s3ObjectSummary2 = new S3ObjectSummary();
-    s3ObjectSummary1.setKey(key1);
-    s3ObjectSummary2.setKey(key2);
-    ObjectMetadata objectMetadata1 = new ObjectMetadata();
-    ObjectMetadata objectMetadata2 = new ObjectMetadata();
-    objectMetadata1.setContentLength(100L);
-    objectMetadata2.setContentLength(50L);
-    when(mockAmazonS3.getObjectMetadata(bucket, key1)).thenReturn(objectMetadata1);
-    when(mockAmazonS3.getObjectMetadata(bucket, key2)).thenReturn(objectMetadata2);
-
-    ListObjectsV2Result objectsAtPath = mock(ListObjectsV2Result.class);
-    when(objectsAtPath.getObjectSummaries()).thenReturn(Arrays.asList(s3ObjectSummary1, s3ObjectSummary2));
-    when(mockAmazonS3.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(objectsAtPath);
-
-    DeleteObjectsResult.DeletedObject deletedObject1 = new DeleteObjectsResult.DeletedObject();
-    deletedObject1.setKey(key1);
-    DeleteObjectsResult deleteObjectsResult1 = new DeleteObjectsResult(Collections.singletonList(deletedObject1));
-    when(mockAmazonS3.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(deleteObjectsResult1);
-  }
-
-  @Test
   void sentinelFileForTableDirectory() {
     String partitionSentinel = "table/id1/partition_1_$folder$";
     String partitionParentSentinel = "table/id1_$folder$";
@@ -377,26 +339,16 @@ class S3PathCleanerTest {
 
   @Test
   void reportBytesDeletedWhenDirectoryDeletionPartiallyFails() {
-    S3Client mockS3Client = mock(S3Client.class);
+    AmazonS3 mockAmazonS3 = mock(AmazonS3.class);
+    S3Client mockS3Client = new S3Client(mockAmazonS3, false);
+    mockOneOutOfTwoObjectsDeleted(mockAmazonS3);
     s3PathCleaner = new S3PathCleaner(mockS3Client, s3SentinelFilesCleaner, bytesDeletedReporter);
-    S3ObjectSummary s3ObjectSummary = new S3ObjectSummary();
-    s3ObjectSummary.setBucketName(bucket);
-    s3ObjectSummary.setKey(key1);
-    S3ObjectSummary s3ObjectSummary2 = new S3ObjectSummary();
-    s3ObjectSummary2.setBucketName(bucket);
-    s3ObjectSummary2.setKey(key2);
-//    when(mockS3Client.listObjects(bucket, keyRoot + "/")).thenReturn(listObjectsV2Resultist.of(s3ObjectSummary
-//      , s3ObjectSummary2));
-    int bytes = 10;
-    ObjectMetadata objectMetadata = new ObjectMetadata();
-    objectMetadata.setContentLength(bytes);
-    when(mockS3Client.getObjectMetadata(bucket, key1)).thenReturn(objectMetadata);
-    when(mockS3Client.getObjectMetadata(bucket, key2)).thenReturn(objectMetadata);
-    when(mockS3Client.deleteObjects(bucket, List.of(key1, key2))).thenReturn(List.of(key1));
-
     assertThatExceptionOfType(BeekeeperException.class)
-      .isThrownBy(() -> s3PathCleaner.cleanupPath(housekeepingPath));
-    verify(bytesDeletedReporter).reportTaggable(bytes, housekeepingPath, FileSystemType.S3);
+      .isThrownBy(() -> s3PathCleaner.cleanupPath(housekeepingPath))
+      .withMessage(format("Not all files could be deleted at path \"%s/%s\"; deleted 1/2 objects. "
+          + "Objects not deleted: 'table/id1/partition_1/file2'.", bucket,
+        keyRootAsDirectory));
+    verify(bytesDeletedReporter).reportTaggable(100L, housekeepingPath, FileSystemType.S3);
   }
 
   @Test
@@ -406,5 +358,23 @@ class S3PathCleanerTest {
     assertThatExceptionOfType(BeekeeperException.class)
       .isThrownBy(() -> s3PathCleaner.cleanupPath(housekeepingPath))
       .withMessage(format("'%s' is not an S3 path.", path));
+  }
+
+  private void mockOneOutOfTwoObjectsDeleted(AmazonS3 mockAmazonS3) {
+    S3ObjectSummary s3ObjectSummary = new S3ObjectSummary();
+    s3ObjectSummary.setBucketName(bucket);
+    s3ObjectSummary.setKey(key1);
+    s3ObjectSummary.setSize(100L);
+    S3ObjectSummary s3ObjectSummary2 = new S3ObjectSummary();
+    s3ObjectSummary2.setBucketName(bucket);
+    s3ObjectSummary2.setKey(key2);
+    s3ObjectSummary2.setSize(50L);
+    ListObjectsV2Result listObjectsV2Result = mock(ListObjectsV2Result.class);
+    when(listObjectsV2Result.getObjectSummaries()).thenReturn(List.of(s3ObjectSummary, s3ObjectSummary2));
+    when(mockAmazonS3.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(listObjectsV2Result);
+    DeleteObjectsResult.DeletedObject deletedObject = new DeleteObjectsResult.DeletedObject();
+    deletedObject.setKey(key1);
+    when(mockAmazonS3.deleteObjects(any(DeleteObjectsRequest.class)))
+      .thenReturn(new DeleteObjectsResult(List.of(deletedObject)));
   }
 }


### PR DESCRIPTION
PR to do batch deletes of partition files, with a little refactoring in as I found that `S3ObjectSummary` contains the file size - so no need to re-lookup.