### PR TITLE
trim github action build down

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ExpediaGroup/beekeeper-commiters

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,26 +4,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Run all tests
+    name: Package and run all tests
     runs-on: ubuntu-18.04
-    timeout-minutes: 20
     steps:
+    - uses: actions/checkout@v1
     - name: Set up JDK 1.11
       uses: actions/setup-java@v1
       with:
         java-version: 1.11
-
-    - uses: actions/checkout@v1
-    
-    - name: Cache
-      uses: actions/cache@v1.1.0
-      with:
-        key: maven-cache
-        path: ~/.m2/repository
-    
-    - name: Install Maven Dependencies
-      run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true --quiet --batch-mode --show-version --activate-profiles travis
-
     - name: Run Maven Package
       run: mvn package --batch-mode --show-version --activate-profiles travis
-


### PR DESCRIPTION
From looking at the GH actions output I think we can remove some of the steps. I don't think the cache is working and we probably don't really need it if we only run one action. I think we inherited the "install" step from how we did things in Travis but I don't think we need it. I also removed the timeout as I'd rather use GH's default and only specifically configure values for things if we need to.