### PR TITLE
Update to log4j 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <jdk.version>11</jdk.version>
     <junit.jupiter.version>5.6.0</junit.jupiter.version>
     <logback.version>1.2.3</logback.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <lombok.version>1.18.20</lombok.version>
     <maven.assembly.plugin.version>3.1.0</maven.assembly.plugin.version>
     <mockito.version>3.11.2</mockito.version>


### PR DESCRIPTION
See https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

Motivation:

log4j 2.16 was recently discovered to be vulnerable to an infinite recursion DOS. Version 2.17 fixes LOG4J2-3230.

Modification:

Change the POM from 2.16 to 2.17 for log4j.

Result:

This PR updates log4j to 2.17, which includes a patch for the issue.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/beekeeper/blob/main/CONTRIBUTING.md
-->

Fixes #
