### PR TITLE
Separate table deletion to its own config item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.6.0] - 2025-03-12
 ## Added
-- Added the `table.deletion.enabled` property to separate table deletion into its own configuration item.
+- Added the `beekeeper.expired.data.table.deletion.enabled` property to separate table deletion into its own configuration item. 
+- Note: Before this release, partitioned tables were automatically deleted when all partitions expired. This is now considered a bug and the default behavior has changed, but you can restore the previous behavior by enabling this property.
+  
 
 ## [3.5.13] - 2025-01-24
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.0] - 2025-03-24
+## [3.6.0] - 2025-03-25
 ## Added
 - Added the `beekeeper.expired.data.table.deletion.enabled` property to separate table deletion into its own configuration item. 
 - Note: Before this release, partitioned tables were automatically deleted when all partitions expired. This is now considered a bug and the default behavior has changed, but you can restore the previous behavior by enabling this property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.0] - 2025-03-12
+## Added
+- Added the `table.deletion.enabled` property to separate table deletion into its own configuration item.
 
 ## [3.5.13] - 2025-01-24
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.0] - 2025-03-12
+## [3.6.0] - 2025-03-24
 ## Added
 - Added the `beekeeper.expired.data.table.deletion.enabled` property to separate table deletion into its own configuration item. 
 - Note: Before this release, partitioned tables were automatically deleted when all partitions expired. This is now considered a bug and the default behavior has changed, but you can restore the previous behavior by enabling this property.
-  
 
 ## [3.5.13] - 2025-01-24
 ## Added

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Beekeeper only actions on events which are marked with specific parameters. Thes
 | `beekeeper.hive.event.whitelist=X` | No | Comma separated list of event types to whitelist for orphaned data. Valid event values are: `alter_partition`, `alter_table`, `drop_table`, `drop_partition`. | Beekeeper will only process whitelisted events. Default value: `alter_partition`, `alter_table`. |
 | `beekeeper.remove.expired.data=true`   | Yes |  `true` or `false`       | Set this parameter to enable TTL on your table. |
 | `beekeeper.expired.data.retention.period=X` | No | e.g. `P7D` or `PT3H` (based on [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601)) | Set this parameter to control the TTL duration for your table. If this is either not set, or configured incorrectly, the default value of `P30D` (30 days) will be used. |
+| `beekeeper.table.deletion.enabled`               | No |`true` or `false` | Enable to allow tables with no partitions to be deleted. Default is `false`. |
 
 **Usage**
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Beekeeper only actions on events which are marked with specific parameters. Thes
 | `beekeeper.hive.event.whitelist=X` | No | Comma separated list of event types to whitelist for orphaned data. Valid event values are: `alter_partition`, `alter_table`, `drop_table`, `drop_partition`. | Beekeeper will only process whitelisted events. Default value: `alter_partition`, `alter_table`. |
 | `beekeeper.remove.expired.data=true`   | Yes |  `true` or `false`       | Set this parameter to enable TTL on your table. |
 | `beekeeper.expired.data.retention.period=X` | No | e.g. `P7D` or `PT3H` (based on [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601)) | Set this parameter to control the TTL duration for your table. If this is either not set, or configured incorrectly, the default value of `P30D` (30 days) will be used. |
-| `beekeeper.table.deletion.enabled`               | No |`true` or `false` | Enable to allow tables with no partitions to be deleted. Default is `false`. |
+| `beekeeper.expired.data.table.deletion.enabled`               | No |`true` or `false` | Whether to delete a partitioned table when all partitions are expired. Default is `false`.                                                                                             |
 
 **Usage**
 

--- a/beekeeper-api/pom.xml
+++ b/beekeeper-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-api</artifactId>

--- a/beekeeper-cleanup/pom.xml
+++ b/beekeeper-cleanup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-cleanup</artifactId>

--- a/beekeeper-core/pom.xml
+++ b/beekeeper-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-core</artifactId>

--- a/beekeeper-integration-tests/pom.xml
+++ b/beekeeper-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-integration-tests</artifactId>

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperDryRunMetadataCleanupIntegrationTest.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperDryRunMetadataCleanupIntegrationTest.java
@@ -28,6 +28,7 @@ import static com.expediagroup.beekeeper.integration.CommonTestVariables.LONG_CL
 import static com.expediagroup.beekeeper.integration.CommonTestVariables.TABLE_NAME_VALUE;
 
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -193,7 +194,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunDropUnpartitionedTable() throws TException, SQLException {
-    hiveTestUtils.createTable(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false);
+    hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, createBeeKeeperDeletionProperties(), true);
     amazonS3.putObject(BUCKET, UNPARTITIONED_TABLE_OBJECT_KEY, TABLE_DATA);
     insertExpiredMetadata(UNPARTITIONED_TABLE_PATH, null);
 
@@ -207,7 +208,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunDropPartitionedTable() throws Exception {
-    Table table = hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
     amazonS3.putObject(BUCKET, PARTITIONED_OBJECT_KEY, TABLE_DATA);
@@ -225,7 +226,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunDontDropPartitionedTable() throws Exception {
-    Table table = hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
     hiveTestUtils
         .addPartitionsToTable(PARTITION_ROOT_PATH, table, List.of("2020-01-01", "1", "B"));
@@ -254,7 +255,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunMetrics() throws Exception {
-    Table table = hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
 
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
@@ -312,5 +313,11 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
       }
     }
     assertThat(logsFromHiveClient).isEqualTo(expected);
+  }
+
+  private Map<String, String> createBeeKeeperDeletionProperties() {
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("beekeeper.table.deletion.enabled", "true");
+    return tableProperties;
   }
 }

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperDryRunMetadataCleanupIntegrationTest.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperDryRunMetadataCleanupIntegrationTest.java
@@ -317,7 +317,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   private Map<String, String> createBeeKeeperDeletionProperties() {
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put("beekeeper.table.deletion.enabled", "true");
+    tableProperties.put("beekeeper.expired.data.table.deletion.enabled", "true");
     return tableProperties;
   }
 }

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperDryRunMetadataCleanupIntegrationTest.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperDryRunMetadataCleanupIntegrationTest.java
@@ -28,7 +28,6 @@ import static com.expediagroup.beekeeper.integration.CommonTestVariables.LONG_CL
 import static com.expediagroup.beekeeper.integration.CommonTestVariables.TABLE_NAME_VALUE;
 
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -194,7 +193,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunDropUnpartitionedTable() throws TException, SQLException {
-    hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, createBeeKeeperDeletionProperties(), true);
+    hiveTestUtils.createTableWithDeletionProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, true);
     amazonS3.putObject(BUCKET, UNPARTITIONED_TABLE_OBJECT_KEY, TABLE_DATA);
     insertExpiredMetadata(UNPARTITIONED_TABLE_PATH, null);
 
@@ -208,7 +207,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunDropPartitionedTable() throws Exception {
-    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
+    Table table = hiveTestUtils.createTableWithDeletionProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
     amazonS3.putObject(BUCKET, PARTITIONED_OBJECT_KEY, TABLE_DATA);
@@ -226,7 +225,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunDontDropPartitionedTable() throws Exception {
-    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
+    Table table = hiveTestUtils.createTableWithDeletionProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
     hiveTestUtils
         .addPartitionsToTable(PARTITION_ROOT_PATH, table, List.of("2020-01-01", "1", "B"));
@@ -255,7 +254,7 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
 
   @Test
   public void dryRunMetrics() throws Exception {
-    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
+    Table table = hiveTestUtils.createTableWithDeletionProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
 
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
@@ -315,9 +314,4 @@ public class BeekeeperDryRunMetadataCleanupIntegrationTest extends BeekeeperInte
     assertThat(logsFromHiveClient).isEqualTo(expected);
   }
 
-  private Map<String, String> createBeeKeeperDeletionProperties() {
-    Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put("beekeeper.expired.data.table.deletion.enabled", "true");
-    return tableProperties;
-  }
 }

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperMetadataCleanupIntegrationTest.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperMetadataCleanupIntegrationTest.java
@@ -199,7 +199,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   @Test
   public void cleanupUnpartitionedTable() throws TException, SQLException {
-    hiveTestUtils.createTable(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false);
+    hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, createBeeKeeperDeletionProperties(), true);
     amazonS3.putObject(BUCKET, UNPARTITIONED_OBJECT_KEY, TABLE_DATA);
 
     insertExpiredMetadata(UNPARTITIONED_TABLE_PATH, null);
@@ -213,7 +213,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   @Test
   public void cleanupPartitionedTable() throws Exception {
-    Table table = hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
 
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
@@ -284,7 +284,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   @Test
   public void cleanupPartitionedTableWithNoPartitions() throws TException, SQLException {
-    hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
 
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, TABLE_DATA);
     insertExpiredMetadata(PARTITIONED_TABLE_PATH, null);
@@ -342,10 +342,10 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   @Test
   public void cleanupMultipleTablesOfMixedType() throws Exception {
-    hiveTestUtils.createTable(UNPARTITIONED_TABLE_PATH, UNPARTITIONED_TABLE_NAME, false);
+    hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, UNPARTITIONED_TABLE_NAME, false, createBeeKeeperDeletionProperties(), true);
 
     Table partitionedTable = hiveTestUtils
-        .createTable(PARTITIONED_TABLE_PATH, PARTITIONED_TABLE_NAME, true);
+        .createTableWithProperties(PARTITIONED_TABLE_PATH, PARTITIONED_TABLE_NAME, true, createBeeKeeperDeletionProperties(), true);
     hiveTestUtils
         .addPartitionsToTable(PARTITION_ROOT_PATH, partitionedTable, PARTITION_VALUES);
 
@@ -376,7 +376,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   @Test
   public void onlyCleanupLocationWhenPartitionExists() throws TException, SQLException {
-    hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties() ,true);
 
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
     amazonS3.putObject(BUCKET, PARTITIONED_OBJECT_KEY, TABLE_DATA);
@@ -394,7 +394,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   @Test
   public void testEventAddedToHistoryTable() throws TException, SQLException {
-    hiveTestUtils.createTable(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false);
+    hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, createBeeKeeperDeletionProperties(), true);
     amazonS3.putObject(BUCKET, UNPARTITIONED_OBJECT_KEY, TABLE_DATA);
 
     insertExpiredMetadata(UNPARTITIONED_TABLE_PATH, null);
@@ -414,8 +414,39 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
   }
 
   @Test
+  public void tableNotDeletedWhenDeletionPropertyIsFalse() throws TException, SQLException {
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("beekeeper.table.deletion.enabled", "false");
+
+    hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, tableProperties, true);
+    amazonS3.putObject(BUCKET, UNPARTITIONED_OBJECT_KEY, TABLE_DATA);
+
+    insertExpiredMetadata(UNPARTITIONED_TABLE_PATH, null);
+    await()
+        .atMost(TIMEOUT, TimeUnit.SECONDS)
+        .until(() -> getExpiredMetadata().get(0).getHousekeepingStatus() == SKIPPED);
+
+    assertThat(metastoreClient.tableExists(DATABASE_NAME_VALUE, TABLE_NAME_VALUE)).isTrue();
+    assertThat(amazonS3.doesObjectExist(BUCKET, UNPARTITIONED_OBJECT_KEY)).isTrue();
+  }
+
+  @Test
+  public void tableNotDeletedWhenDeletionPropertyNotSet() throws TException, SQLException {
+    hiveTestUtils.createTable(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false);
+    amazonS3.putObject(BUCKET, UNPARTITIONED_OBJECT_KEY, TABLE_DATA);
+
+    insertExpiredMetadata(UNPARTITIONED_TABLE_PATH, null);
+    await()
+        .atMost(TIMEOUT, TimeUnit.SECONDS)
+        .until(() -> getExpiredMetadata().get(0).getHousekeepingStatus() == SKIPPED);
+
+    assertThat(metastoreClient.tableExists(DATABASE_NAME_VALUE, TABLE_NAME_VALUE)).isTrue();
+    assertThat(amazonS3.doesObjectExist(BUCKET, UNPARTITIONED_OBJECT_KEY)).isTrue();
+  }
+
+  @Test
   public void metrics() throws Exception {
-    Table table = hiveTestUtils.createTable(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true);
+    Table table = hiveTestUtils.createTableWithProperties(PARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, true, createBeeKeeperDeletionProperties(), true);
     hiveTestUtils.addPartitionsToTable(PARTITION_ROOT_PATH, table, PARTITION_VALUES);
 
     amazonS3.putObject(BUCKET, PARTITIONED_TABLE_OBJECT_KEY, "");
@@ -442,6 +473,12 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
           .contains("metadata-cleanup-job", "hive-table-deleted", "hive-partition-deleted", "hive-table-" + METRIC_NAME,
               "hive-partition-" + METRIC_NAME, "s3-paths-deleted", "s3-" + BytesDeletedReporter.METRIC_NAME);
     });
+  }
+
+  private Map<String, String> createBeeKeeperDeletionProperties() {
+    Map<String, String> tableProperties = new HashMap<>();
+    tableProperties.put("beekeeper.table.deletion.enabled", "true");
+    return tableProperties;
   }
 
   @Test

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperMetadataCleanupIntegrationTest.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/BeekeeperMetadataCleanupIntegrationTest.java
@@ -416,7 +416,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
   @Test
   public void tableNotDeletedWhenDeletionPropertyIsFalse() throws TException, SQLException {
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put("beekeeper.table.deletion.enabled", "false");
+    tableProperties.put("beekeeper.expired.data.table.deletion.enabled", "false");
 
     hiveTestUtils.createTableWithProperties(UNPARTITIONED_TABLE_PATH, TABLE_NAME_VALUE, false, tableProperties, true);
     amazonS3.putObject(BUCKET, UNPARTITIONED_OBJECT_KEY, TABLE_DATA);
@@ -477,7 +477,7 @@ public class BeekeeperMetadataCleanupIntegrationTest extends BeekeeperIntegratio
 
   private Map<String, String> createBeeKeeperDeletionProperties() {
     Map<String, String> tableProperties = new HashMap<>();
-    tableProperties.put("beekeeper.table.deletion.enabled", "true");
+    tableProperties.put("beekeeper.expired.data.table.deletion.enabled", "true");
     return tableProperties;
   }
 

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/utils/HiveTestUtils.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/utils/HiveTestUtils.java
@@ -143,4 +143,15 @@ public class HiveTestUtils {
 
     return hiveTable;
   }
+
+  public Table createTableWithDeletionProperties(String path, String tableName, boolean partitioned,
+      boolean shouldTableBeDeletedIfEmpty) throws TException {
+    Map<String, String> tableProperties = new HashMap<>();
+    if (shouldTableBeDeletedIfEmpty) {
+      tableProperties.put("beekeeper.expired.data.table.deletion.enabled", "true");
+    } else {
+      tableProperties.put("beekeeper.expired.data.table.deletion.enabled", "false");
+    }
+    return createTableWithProperties(path, tableName, partitioned, tableProperties, true);
+  }
 }

--- a/beekeeper-metadata-cleanup/pom.xml
+++ b/beekeeper-metadata-cleanup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-metadata-cleanup</artifactId>

--- a/beekeeper-metadata-cleanup/src/main/java/com/expediagroup/beekeeper/metadata/cleanup/handler/ExpiredMetadataHandler.java
+++ b/beekeeper-metadata-cleanup/src/main/java/com/expediagroup/beekeeper/metadata/cleanup/handler/ExpiredMetadataHandler.java
@@ -44,7 +44,7 @@ import com.expediagroup.beekeeper.core.validation.S3PathValidator;
 public class ExpiredMetadataHandler implements MetadataHandler {
 
   private final Logger log = LoggerFactory.getLogger(ExpiredMetadataHandler.class);
-  private static final String TABLE_DELETION_PROPERTY = "beekeeper.table.deletion.enabled";
+  private static final String TABLE_DELETION_PROPERTY = "beekeeper.expired.data.table.deletion.enabled";
 
   private final CleanerClientFactory cleanerClientFactory;
   private final HousekeepingMetadataRepository housekeepingMetadataRepository;

--- a/beekeeper-metadata-cleanup/src/main/java/com/expediagroup/beekeeper/metadata/cleanup/handler/ExpiredMetadataHandler.java
+++ b/beekeeper-metadata-cleanup/src/main/java/com/expediagroup/beekeeper/metadata/cleanup/handler/ExpiredMetadataHandler.java
@@ -136,7 +136,7 @@ public class ExpiredMetadataHandler implements MetadataHandler {
     if (!isTableDeletionEnabled(client, databaseName, tableName)) {
       log.info("Skipping table drop for '{}.{}' as table deletion is disabled.", databaseName, tableName);
       updateAttemptsAndStatus(housekeepingMetadata, SKIPPED);
-      saveHistory(housekeepingMetadata, SKIPPED, dryRunEnabled); // should we set it to skipped when we avoid deletion?
+      saveHistory(housekeepingMetadata, SKIPPED, dryRunEnabled);
       return false;
     }
 

--- a/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/handler/ExpiredMetadataHandlerTest.java
+++ b/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/handler/ExpiredMetadataHandlerTest.java
@@ -110,7 +110,7 @@ public class ExpiredMetadataHandlerTest {
     when(housekeepingMetadata.getTableName()).thenReturn(TABLE_NAME);
     when(housekeepingMetadata.getPartitionName()).thenReturn(null);
     when(hiveClient.getTableProperties(DATABASE, TABLE_NAME))
-        .thenReturn(Collections.singletonMap("beekeeper.table.deletion.enabled", "true"));
+        .thenReturn(Collections.singletonMap("beekeeper.expired.data.table.deletion.enabled", "true"));
     when(housekeepingMetadata.getPath()).thenReturn(VALID_TABLE_PATH);
     when(housekeepingMetadata.getCleanupAttempts()).thenReturn(0);
     when(
@@ -155,7 +155,7 @@ public class ExpiredMetadataHandlerTest {
     when(housekeepingMetadata.getTableName()).thenReturn(TABLE_NAME);
     when(housekeepingMetadata.getPartitionName()).thenReturn(null);
     when(hiveClient.getTableProperties(DATABASE, TABLE_NAME))
-        .thenReturn(Collections.singletonMap("beekeeper.table.deletion.enabled", "true"));
+        .thenReturn(Collections.singletonMap("beekeeper.expired.data.table.deletion.enabled", "true"));
     when(housekeepingMetadata.getPath()).thenReturn(VALID_TABLE_PATH);
     when(hiveMetadataCleaner.tableExists(hiveClient, DATABASE, TABLE_NAME)).thenReturn(true);
 
@@ -257,7 +257,7 @@ public class ExpiredMetadataHandlerTest {
     when(housekeepingMetadata.getPartitionName()).thenReturn(null);
     when(housekeepingMetadata.getPath()).thenReturn(VALID_TABLE_PATH);
     when(hiveClient.getTableProperties(DATABASE, TABLE_NAME))
-        .thenReturn(Collections.singletonMap("beekeeper.table.deletion.enabled", "true"));
+        .thenReturn(Collections.singletonMap("beekeeper.expired.data.table.deletion.enabled", "true"));
     when(housekeepingMetadata.getCleanupAttempts()).thenReturn(0);
     when(housekeepingMetadataRepository.countRecordsForGivenDatabaseAndTableWherePartitionIsNotNull(DATABASE, TABLE_NAME))
         .thenReturn(Long.valueOf(0));
@@ -335,7 +335,7 @@ public class ExpiredMetadataHandlerTest {
     when(housekeepingMetadata.getTableName()).thenReturn(TABLE_NAME);
     when(housekeepingMetadata.getPartitionName()).thenReturn(null);
     when(hiveClient.getTableProperties(DATABASE, TABLE_NAME))
-        .thenReturn(Collections.singletonMap("beekeeper.table.deletion.enabled", "true"));
+        .thenReturn(Collections.singletonMap("beekeeper.expired.data.table.deletion.enabled", "true"));
     when(housekeepingMetadata.getPath()).thenReturn(VALID_TABLE_PATH);
     when(housekeepingMetadata.getCleanupAttempts()).thenReturn(0);
     when(
@@ -358,7 +358,7 @@ public class ExpiredMetadataHandlerTest {
     when(housekeepingMetadata.getTableName()).thenReturn(TABLE_NAME);
     when(housekeepingMetadata.getPartitionName()).thenReturn(null);
     when(hiveClient.getTableProperties(DATABASE, TABLE_NAME))
-        .thenReturn(Collections.singletonMap("beekeeper.table.deletion.enabled", "true"));
+        .thenReturn(Collections.singletonMap("beekeeper.expired.data.table.deletion.enabled", "true"));
     when(housekeepingMetadata.getPath()).thenReturn(VALID_TABLE_PATH);
     when(housekeepingMetadata.getCleanupAttempts()).thenReturn(0);
     when(hiveMetadataCleaner.tableExists(hiveClient, DATABASE, TABLE_NAME)).thenReturn(true);
@@ -397,7 +397,7 @@ public class ExpiredMetadataHandlerTest {
     when(housekeepingMetadata.getPath()).thenReturn(VALID_TABLE_PATH);
     when(housekeepingMetadata.getPartitionName()).thenReturn(null);
     when(hiveClient.getTableProperties(DATABASE, TABLE_NAME))
-        .thenReturn(Collections.singletonMap("beekeeper.table.deletion.enabled", "false"));
+        .thenReturn(Collections.singletonMap("beekeeper.expired.data.table.deletion.enabled", "false"));
     when(housekeepingMetadataRepository
         .countRecordsForGivenDatabaseAndTableWherePartitionIsNotNull(DATABASE, TABLE_NAME))
         .thenReturn(0L);

--- a/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/service/PagingMetadataCleanupServiceTest.java
+++ b/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/service/PagingMetadataCleanupServiceTest.java
@@ -104,7 +104,7 @@ public class PagingMetadataCleanupServiceTest {
     when(metadataCleaner.dropPartition(Mockito.any(), Mockito.any())).thenReturn(true);
     Map<String, String> properties = new HashMap<>();
     properties.put(UNREFERENCED.getTableParameterName(), "true");
-    properties.put("beekeeper.table.deletion.enabled", "true");
+    properties.put("beekeeper.expired.data.table.deletion.enabled", "true");
     when(hiveClient.getTableProperties(Mockito.anyString(), Mockito.anyString()))
         .thenReturn(properties);
     when(hiveClientFactory.newInstance()).thenReturn(hiveClient);

--- a/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/service/PagingMetadataCleanupServiceTest.java
+++ b/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/service/PagingMetadataCleanupServiceTest.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,10 @@ public class PagingMetadataCleanupServiceTest {
     when(metadataCleaner.dropPartition(Mockito.any(), Mockito.any())).thenReturn(true);
     Map<String, String> properties = new HashMap<>();
     properties.put(UNREFERENCED.getTableParameterName(), "true");
-    when(hiveClient.getTableProperties(Mockito.any(), Mockito.any())).thenReturn(properties);
+    properties.put("beekeeper.table.deletion.enabled", "true");
+    when(hiveClient.getTableProperties(Mockito.anyString(), Mockito.anyString()))
+        .thenReturn(properties);
+    when(hiveClientFactory.newInstance()).thenReturn(hiveClient);
     when(hiveClientFactory.newInstance()).thenReturn(hiveClient);
     handler = new ExpiredMetadataHandler(hiveClientFactory, metadataRepository, metadataCleaner, pathCleaner,
         beekeeperHistoryService);

--- a/beekeeper-path-cleanup/pom.xml
+++ b/beekeeper-path-cleanup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-path-cleanup</artifactId>

--- a/beekeeper-scheduler-apiary/pom.xml
+++ b/beekeeper-scheduler-apiary/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-scheduler-apiary</artifactId>

--- a/beekeeper-scheduler/pom.xml
+++ b/beekeeper-scheduler/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-scheduler</artifactId>

--- a/beekeeper-vacuum-tool/pom.xml
+++ b/beekeeper-vacuum-tool/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.5.14-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-vacuum-tool</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>beekeeper-parent</artifactId>
-  <version>3.5.14-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <description>Beekeeper is a service which manages the cleanup of tables and unreferenced S3 paths.</description>
   <inceptionYear>2019</inceptionYear>
   <packaging>pom</packaging>


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/beekeeper/blob/main/CONTRIBUTING.md
-->

Addressing [Issue 177](https://github.com/ExpediaGroup/beekeeper/issues/177)

This PR adds a new configuration property, `beekeeper.table.deletion.enabled`, to control the deletion behavior for Hive tables.

When set to `true`, the table will be deleted—provided all conditions are met (e.g., the table has zero partitions, the path is valid, and the table exists)

The default value of `beekeeper.table.deletion.enabled` is `false`.

If `beekeeper.table.deletion.enabled` is `false`, then the `cleanUpTable` method will return `false`, and the table deletion will be _SKIPPED_.
