### PR TITLE
Use partition createTime in the event listener path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.2] - 2025-06-10
+## [3.6.2] - 2025-06-17
 ## Fixed
 - Extended the use of Hive's partition `createTime` to event-driven scheduling. Cleanup events are now scheduled based on the partition's actual creation time in Hive, not the event processing time.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.1] - 2025-05-14
+## [3.6.2] - 2025-06-10
+## Fixed
+- Extended the use of Hive's partition `createTime` to event-driven scheduling. Cleanup events are now scheduled based on the partition's actual creation time in Hive, not the event processing time.
+
+- ## [3.6.1] - 2025-05-14
 ## Fixed
 - Use Hive partition creation time (`createTime`) for scheduling partition cleanup, ensuring accurate expiry timing for both new and existing partitions.
 - Updated workflows to use `Ubuntu 22.04` instead of `Ubuntu 20.04`.

--- a/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/context/CommonBeans.java
+++ b/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/context/CommonBeans.java
@@ -116,8 +116,9 @@ public class CommonBeans {
 
   @Bean(name = "expiredHousekeepingMetadataGenerator")
   public HousekeepingEntityGenerator expiredHousekeepingMetadataGenerator(
-      @Value("${properties.beekeeper.default-expiration-delay}") String cleanupDelay) {
-    return new ExpiredHousekeepingMetadataGenerator(cleanupDelay);
+      @Value("${properties.beekeeper.default-expiration-delay}") String cleanupDelay,
+      @Qualifier("hiveClientFactory") HiveClientFactory hiveClientFactory) {
+    return new ExpiredHousekeepingMetadataGenerator(cleanupDelay, hiveClientFactory);
   }
 
   @Bean(name = "expiredHousekeepingMetadataMessageEventHandler")

--- a/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
+++ b/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
@@ -145,13 +145,8 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
       String partitionName) {
     PeriodDuration cleanupDelay = cleanupDelayExtractor.extractCleanupDelay(listenerEvent);
     
-    LocalDateTime creationTime;
-    if (partitionName != null) {
-      creationTime = getPartitionCreationTime(listenerEvent.getDbName(), listenerEvent.getTableName(), partitionName);
-    } else {
-      creationTime = LocalDateTime.now(clock);
-    }
-             
+    LocalDateTime creationTime = getPartitionCreationTime(listenerEvent.getDbName(), listenerEvent.getTableName(), partitionName);
+    
     return HousekeepingMetadata
         .builder()
         .housekeepingStatus(SCHEDULED)
@@ -181,6 +176,10 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
   }
   
   private LocalDateTime getPartitionCreationTime(String databaseName, String tableName, String partitionName) {
+    if (partitionName == null) {
+      return LocalDateTime.now(clock);
+    }
+    
     try (HiveClient hiveClient = hiveClientFactory.newInstance()) {
       Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(databaseName, tableName, partitionName);
       

--- a/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
+++ b/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
@@ -144,12 +144,10 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
       String partitionName) {
     PeriodDuration cleanupDelay = cleanupDelayExtractor.extractCleanupDelay(listenerEvent);
     
-    // Get the creation time from Hive if this is a partition
     LocalDateTime creationTime;
     if (partitionName != null) {
       creationTime = getPartitionCreationTime(listenerEvent.getDbName(), listenerEvent.getTableName(), partitionName);
     } else {
-      // For tables, use current time as there's no reliable way to get table creation time
       creationTime = LocalDateTime.now(clock);
     }
     
@@ -184,14 +182,6 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
         .collect(Collectors.joining("/"));
   }
   
-  /**
-   * Gets the creation time of a partition from Hive.
-   * 
-   * @param databaseName The database name
-   * @param tableName The table name
-   * @param partitionName The partition name
-   * @return The partition creation time from Hive, or current time if not available
-   */
   private LocalDateTime getPartitionCreationTime(String databaseName, String tableName, String partitionName) {
     try (HiveClient hiveClient = hiveClientFactory.newInstance()) {
       PartitionInfo partitionInfo = hiveClient.getSinglePartitionInfo(databaseName, tableName, partitionName);

--- a/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
+++ b/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
@@ -176,10 +176,6 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
   }
   
   private LocalDateTime getPartitionCreationTime(String databaseName, String tableName, String partitionName) {
-    if (partitionName == null) {
-      return LocalDateTime.now(clock);
-    }
-    
     try (HiveClient hiveClient = hiveClientFactory.newInstance()) {
       Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(databaseName, tableName, partitionName);
       

--- a/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
+++ b/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -150,9 +151,6 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
     } else {
       creationTime = LocalDateTime.now(clock);
     }
-    
-    log.info("TIMESTAMP_INFO: Creating housekeeping entity with creationTimestamp={} for partition={}", 
-             creationTime, partitionName);
              
     return HousekeepingMetadata
         .builder()
@@ -184,10 +182,10 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
   
   private LocalDateTime getPartitionCreationTime(String databaseName, String tableName, String partitionName) {
     try (HiveClient hiveClient = hiveClientFactory.newInstance()) {
-      PartitionInfo partitionInfo = hiveClient.getSinglePartitionInfo(databaseName, tableName, partitionName);
+      Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(databaseName, tableName, partitionName);
       
-      if (partitionInfo != null) {
-        return partitionInfo.getCreateTime();
+      if (partitionInfo.isPresent()) {
+        return partitionInfo.get().getCreateTime();
       }
       
       log.warn("Partition {} not found in Hive for table {}.{}, using current time",

--- a/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
+++ b/beekeeper-scheduler-apiary/src/main/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGenerator.java
@@ -194,10 +194,10 @@ public class ExpiredHousekeepingMetadataGenerator implements HousekeepingEntityG
    */
   private LocalDateTime getPartitionCreationTime(String databaseName, String tableName, String partitionName) {
     try (HiveClient hiveClient = hiveClientFactory.newInstance()) {
-      Map<String, PartitionInfo> partitionInfo = hiveClient.getTablePartitionsInfo(databaseName, tableName);
+      PartitionInfo partitionInfo = hiveClient.getSinglePartitionInfo(databaseName, tableName, partitionName);
       
-      if (partitionInfo.containsKey(partitionName)) {
-        return partitionInfo.get(partitionName).getCreateTime();
+      if (partitionInfo != null) {
+        return partitionInfo.getCreateTime();
       }
       
       log.warn("Partition {} not found in Hive for table {}.{}, using current time",

--- a/beekeeper-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/apiary/context/CommonBeansTest.java
+++ b/beekeeper-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/apiary/context/CommonBeansTest.java
@@ -46,6 +46,8 @@ import com.expediagroup.beekeeper.scheduler.apiary.generator.UnreferencedHouseke
 import com.expediagroup.beekeeper.scheduler.apiary.handler.MessageEventHandler;
 import com.expediagroup.beekeeper.scheduler.apiary.messaging.BeekeeperEventReader;
 import com.expediagroup.beekeeper.scheduler.apiary.messaging.RetryingMessageReader;
+import com.expediagroup.beekeeper.scheduler.hive.PartitionIteratorFactory;
+import com.expediagroup.beekeeper.scheduler.hive.HiveClientFactory;
 import com.expediagroup.beekeeper.scheduler.service.SchedulerService;
 
 import com.hotels.hcommon.hive.metastore.client.api.CloseableMetaStoreClient;
@@ -110,7 +112,8 @@ public class CommonBeansTest {
 
   @Test
   public void validateExpiredHousekeepingMetadataGenerator() {
-    HousekeepingEntityGenerator generator = commonBeans.expiredHousekeepingMetadataGenerator("P30D");
+    HiveClientFactory mockHiveClientFactory = mock(HiveClientFactory.class);
+    HousekeepingEntityGenerator generator = commonBeans.expiredHousekeepingMetadataGenerator("P30D", mockHiveClientFactory);
     assertThat(generator).isInstanceOf(ExpiredHousekeepingMetadataGenerator.class);
   }
 

--- a/beekeeper-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGeneratorTest.java
+++ b/beekeeper-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGeneratorTest.java
@@ -33,6 +33,7 @@ import static com.expediagroup.beekeeper.core.model.LifecycleEventType.EXPIRED;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,7 +109,7 @@ public class ExpiredHousekeepingMetadataGeneratorTest extends HousekeepingEntity
     when(addPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS);
     when(addPartitionEvent.getPartitionValues()).thenReturn(PARTITION_VALUES);
     when(hiveClientFactory.newInstance()).thenReturn(hiveClient);
-    when(hiveClient.getSinglePartitionInfo(DATABASE, TABLE, PARTITION_NAME)).thenReturn(null);
+    when(hiveClient.getSinglePartitionInfo(DATABASE, TABLE, PARTITION_NAME)).thenReturn(Optional.empty());
 
     List<HousekeepingEntity> housekeepingEntities = generator.generate(addPartitionEvent, CLIENT_ID);
     assertThat(housekeepingEntities.size()).isEqualTo(1);
@@ -123,7 +124,7 @@ public class ExpiredHousekeepingMetadataGeneratorTest extends HousekeepingEntity
     when(alterPartitionEvent.getPartitionKeys()).thenReturn(PARTITION_KEYS);
     when(alterPartitionEvent.getPartitionValues()).thenReturn(PARTITION_VALUES);
     when(hiveClientFactory.newInstance()).thenReturn(hiveClient);
-    when(hiveClient.getSinglePartitionInfo(DATABASE, TABLE, PARTITION_NAME)).thenReturn(null);
+    when(hiveClient.getSinglePartitionInfo(DATABASE, TABLE, PARTITION_NAME)).thenReturn(Optional.empty());
 
     List<HousekeepingEntity> housekeepingEntities = generator.generate(alterPartitionEvent, CLIENT_ID);
     assertThat(housekeepingEntities.size()).isEqualTo(1);
@@ -162,7 +163,7 @@ public class ExpiredHousekeepingMetadataGeneratorTest extends HousekeepingEntity
     when(hiveClientFactory.newInstance()).thenReturn(hiveClient);
     LocalDateTime hiveCreationTime = LocalDateTime.of(2023, 6, 15, 10, 30);
     PartitionInfo partitionInfo = new PartitionInfo(PARTITION_PATH, hiveCreationTime);
-    when(hiveClient.getSinglePartitionInfo(DATABASE, TABLE, PARTITION_NAME)).thenReturn(partitionInfo);
+    when(hiveClient.getSinglePartitionInfo(DATABASE, TABLE, PARTITION_NAME)).thenReturn(Optional.of(partitionInfo));
 
     List<HousekeepingEntity> housekeepingEntities = generator.generate(addPartitionEvent, CLIENT_ID);
     

--- a/beekeeper-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGeneratorTest.java
+++ b/beekeeper-scheduler-apiary/src/test/java/com/expediagroup/beekeeper/scheduler/apiary/generator/ExpiredHousekeepingMetadataGeneratorTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.anyString;
 
 import static com.expedia.apiary.extensions.receiver.common.event.EventType.ADD_PARTITION;
 import static com.expedia.apiary.extensions.receiver.common.event.EventType.ALTER_PARTITION;
@@ -32,6 +33,7 @@ import static com.expediagroup.beekeeper.core.model.LifecycleEventType.EXPIRED;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +52,9 @@ import com.expedia.apiary.extensions.receiver.common.event.DropTableEvent;
 import com.expediagroup.beekeeper.core.error.BeekeeperException;
 import com.expediagroup.beekeeper.core.model.HousekeepingEntity;
 import com.expediagroup.beekeeper.core.model.HousekeepingMetadata;
+import com.expediagroup.beekeeper.scheduler.hive.HiveClient;
+import com.expediagroup.beekeeper.scheduler.hive.HiveClientFactory;
+import com.expediagroup.beekeeper.scheduler.hive.PartitionInfo;
 
 @ExtendWith(MockitoExtension.class)
 public class ExpiredHousekeepingMetadataGeneratorTest extends HousekeepingEntityGeneratorTestBase {
@@ -65,11 +70,16 @@ public class ExpiredHousekeepingMetadataGeneratorTest extends HousekeepingEntity
   @Mock private AlterTableEvent alterTableEvent;
   @Mock private AddPartitionEvent addPartitionEvent;
   @Mock private AlterPartitionEvent alterPartitionEvent;
+  @Mock private HiveClientFactory hiveClientFactory;
+  @Mock private HiveClient hiveClient;
   private ExpiredHousekeepingMetadataGenerator generator;
 
   @BeforeEach
   public void setup() {
-    generator = new ExpiredHousekeepingMetadataGenerator(cleanupDelayExtractor, clock);
+    generator = new ExpiredHousekeepingMetadataGenerator(cleanupDelayExtractor, clock, hiveClientFactory);
+    when(hiveClientFactory.newInstance()).thenReturn(hiveClient);
+    Map<String, PartitionInfo> emptyPartitionInfo = Collections.emptyMap();
+    when(hiveClient.getTablePartitionsInfo(anyString(), anyString())).thenReturn(emptyPartitionInfo);
   }
 
   @Test

--- a/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
+++ b/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -75,10 +76,8 @@ public class HiveClient implements Closeable {
     }
   }
 
-  public PartitionInfo getSinglePartitionInfo(String databaseName, String tableName, String partitionName) {
+  public Optional<PartitionInfo> getSinglePartitionInfo(String databaseName, String tableName, String partitionName) {
     try {
-      Table table = metaStoreClient.getTable(databaseName, tableName);
-      List<FieldSchema> partitionKeys = table.getPartitionKeys();
       List<String> partitionValues = Warehouse.getPartValuesFromPartName(partitionName);
 
       Partition partition = metaStoreClient.getPartition(databaseName, tableName, partitionValues);
@@ -89,11 +88,11 @@ public class HiveClient implements Closeable {
       log.debug("Retrieved partition '{}' with path '{}' for table {}.{}", 
           partitionName, path, databaseName, tableName);
       
-      return new PartitionInfo(path, createTime);
+      return Optional.of(new PartitionInfo(path, createTime));
     } catch (TException e) {
-      log.warn("Failed to get partition info for {}.{}.{}: {}", 
-          databaseName, tableName, partitionName, e.getMessage());
-      return null;
+      log.warn("Failed to get partition info for {}.{}.{}", 
+          databaseName, tableName, partitionName, e);
+      return Optional.empty();
     }
   }
 

--- a/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
+++ b/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
@@ -75,6 +75,28 @@ public class HiveClient implements Closeable {
     }
   }
 
+  public PartitionInfo getSinglePartitionInfo(String databaseName, String tableName, String partitionName) {
+    try {
+      Table table = metaStoreClient.getTable(databaseName, tableName);
+      List<FieldSchema> partitionKeys = table.getPartitionKeys();
+      List<String> partitionValues = Warehouse.getPartValuesFromPartName(partitionName);
+
+      Partition partition = metaStoreClient.getPartition(databaseName, tableName, partitionValues);
+      
+      String path = partition.getSd().getLocation();
+      LocalDateTime createTime = extractCreateTime(partition);
+      
+      log.debug("Retrieved partition '{}' with path '{}' for table {}.{}", 
+          partitionName, path, databaseName, tableName);
+      
+      return new PartitionInfo(path, createTime);
+    } catch (TException e) {
+      log.warn("Failed to get partition info for {}.{}.{}: {}", 
+          databaseName, tableName, partitionName, e.getMessage());
+      return null;
+    }
+  }
+
   private LocalDateTime extractCreateTime(Partition partition) {
     if (partition.getCreateTime() > 0) {
         return LocalDateTime.ofInstant(

--- a/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
+++ b/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
@@ -76,6 +76,15 @@ public class HiveClient implements Closeable {
     }
   }
 
+  /**
+   * Retrieves information for a single partition from Hive metastore.
+   *
+   * @param databaseName the name of the Hive database
+   * @param tableName the name of the Hive table
+   * @param partitionName the partition identifier in Hive's standard format: "key1=value1/key2=value2"
+   *                      (e.g., "event_date=2024-01-01/event_hour=1")
+   * @return Optional containing PartitionInfo if found, empty if partition doesn't exist or on error
+   */
   public Optional<PartitionInfo> getSinglePartitionInfo(String databaseName, String tableName, String partitionName) {
     try {
       List<String> partitionValues = Warehouse.getPartValuesFromPartName(partitionName);

--- a/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
+++ b/beekeeper-scheduler/src/main/java/com/expediagroup/beekeeper/scheduler/hive/HiveClient.java
@@ -82,15 +82,16 @@ public class HiveClient implements Closeable {
    * @param databaseName the name of the Hive database
    * @param tableName the name of the Hive table
    * @param partitionName the partition identifier in Hive's standard format: "key1=value1/key2=value2"
-   *                      (e.g., "event_date=2024-01-01/event_hour=1")
-   * @return Optional containing PartitionInfo if found, empty if partition doesn't exist or on error
+   *                      (e.g., "event_date=2024-01-01/event_hour=1"), or null for table-level events
+   * @return Optional containing PartitionInfo if found, empty if partition doesn't exist, on error, or if partitionName is null
    */
   public Optional<PartitionInfo> getSinglePartitionInfo(String databaseName, String tableName, String partitionName) {
+    if (partitionName == null) {
+      return Optional.empty();
+    }
     try {
       List<String> partitionValues = Warehouse.getPartValuesFromPartName(partitionName);
-
       Partition partition = metaStoreClient.getPartition(databaseName, tableName, partitionValues);
-      
       String path = partition.getSd().getLocation();
       LocalDateTime createTime = extractCreateTime(partition);
       

--- a/beekeeper-scheduler/src/test/java/com/expediagroup/beekeeper/scheduler/hive/hive/HiveClientTest.java
+++ b/beekeeper-scheduler/src/test/java/com/expediagroup/beekeeper/scheduler/hive/hive/HiveClientTest.java
@@ -217,8 +217,6 @@ public class HiveClientTest {
 
   @Test
   public void getSinglePartitionInfoSuccess() throws TException {
-    when(metaStoreClient.getTable(DATABASE_NAME, TABLE_NAME)).thenReturn(table);
-    when(table.getPartitionKeys()).thenReturn(List.of(eventDatePartitionKey, eventHourPartitionKey));
     when(metaStoreClient.getPartition(DATABASE_NAME, TABLE_NAME, List.of("2024-01-01", "1"))).thenReturn(partition);
     when(partition.getSd()).thenReturn(storageDescriptor);
     when(storageDescriptor.getLocation()).thenReturn(PARTITION_PATH);
@@ -234,8 +232,6 @@ public class HiveClientTest {
 
   @Test
   public void getSinglePartitionInfoWithMissingCreateTime() throws TException {
-    when(metaStoreClient.getTable(DATABASE_NAME, TABLE_NAME)).thenReturn(table);
-    when(table.getPartitionKeys()).thenReturn(List.of(eventDatePartitionKey, eventHourPartitionKey));
     when(metaStoreClient.getPartition(DATABASE_NAME, TABLE_NAME, List.of("2024-01-01", "1"))).thenReturn(partition);
     when(partition.getSd()).thenReturn(storageDescriptor);
     when(storageDescriptor.getLocation()).thenReturn(PARTITION_PATH);
@@ -257,7 +253,7 @@ public class HiveClientTest {
 
   @Test
   public void getSinglePartitionInfoNotFound() throws TException {
-    when(metaStoreClient.getTable(DATABASE_NAME, TABLE_NAME)).thenThrow(TException.class);
+    when(metaStoreClient.getPartition(DATABASE_NAME, TABLE_NAME, List.of("2024-01-01", "1"))).thenThrow(TException.class);
 
     Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
     

--- a/beekeeper-scheduler/src/test/java/com/expediagroup/beekeeper/scheduler/hive/hive/HiveClientTest.java
+++ b/beekeeper-scheduler/src/test/java/com/expediagroup/beekeeper/scheduler/hive/hive/HiveClientTest.java
@@ -259,4 +259,11 @@ public class HiveClientTest {
     
     assertThat(partitionInfo).isEmpty();
   }
+
+  @Test
+  public void getSinglePartitionInfoWithNullPartitionName() {
+    Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, null);
+    
+    assertThat(partitionInfo).isEmpty();
+  }
 }

--- a/beekeeper-scheduler/src/test/java/com/expediagroup/beekeeper/scheduler/hive/hive/HiveClientTest.java
+++ b/beekeeper-scheduler/src/test/java/com/expediagroup/beekeeper/scheduler/hive/hive/HiveClientTest.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -223,11 +224,11 @@ public class HiveClientTest {
     when(storageDescriptor.getLocation()).thenReturn(PARTITION_PATH);
     when(partition.getCreateTime()).thenReturn(1234567890);
 
-    PartitionInfo partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
+    Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
     
-    assertThat(partitionInfo).isNotNull();
-    assertThat(partitionInfo.getPath()).isEqualTo(PARTITION_PATH);
-    assertThat(partitionInfo.getCreateTime())
+    assertThat(partitionInfo).isPresent();
+    assertThat(partitionInfo.get().getPath()).isEqualTo(PARTITION_PATH);
+    assertThat(partitionInfo.get().getCreateTime())
         .isEqualTo(LocalDateTime.ofInstant(Instant.ofEpochSecond(1234567890), ZoneId.systemDefault()));
   }
 
@@ -242,13 +243,13 @@ public class HiveClientTest {
 
     LocalDateTime beforeTest = LocalDateTime.now();
     
-    PartitionInfo partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
+    Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
 
     LocalDateTime afterTest = LocalDateTime.now();
     
-    assertThat(partitionInfo).isNotNull();
-    assertThat(partitionInfo.getPath()).isEqualTo(PARTITION_PATH);
-    LocalDateTime createTime = partitionInfo.getCreateTime();
+    assertThat(partitionInfo).isPresent();
+    assertThat(partitionInfo.get().getPath()).isEqualTo(PARTITION_PATH);
+    LocalDateTime createTime = partitionInfo.get().getCreateTime();
     assertThat(createTime).isNotNull();
     assertThat(createTime).isAfterOrEqualTo(beforeTest);
     assertThat(createTime).isBeforeOrEqualTo(afterTest);
@@ -258,8 +259,8 @@ public class HiveClientTest {
   public void getSinglePartitionInfoNotFound() throws TException {
     when(metaStoreClient.getTable(DATABASE_NAME, TABLE_NAME)).thenThrow(TException.class);
 
-    PartitionInfo partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
+    Optional<PartitionInfo> partitionInfo = hiveClient.getSinglePartitionInfo(DATABASE_NAME, TABLE_NAME, PARTITION_NAME);
     
-    assertThat(partitionInfo).isNull();
+    assertThat(partitionInfo).isEmpty();
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/beekeeper/blob/main/CONTRIBUTING.md
-->

In version `3.6.1` we implemented the use of Hive's `createTime` when scheduling partitions for the table discovery path. Meaning when a tag is added onto a table, we use the `createTime` when setting `creationTimestamp` which is used to set the `cleanupTimestamp`.

In this PR we are adding this for the Event path. So when partitions are scheduled based on events, we also use the hive `createTime` for `creationTimestamp`.