### PR TITLE
Upgrade LocalStack to 3.7.0 and switch CI to Temurin JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,3 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
+          distribution: 'temurin'
           java-version: '21'
           java-package: jdk
           server-id: central # Value of the distributionManagement/repository/id field of the pom.xml
@@ -48,3 +48,4 @@ jobs:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        distribution: 'corretto'
+        distribution: 'temurin'
         java-version: '21'
         java-package: jdk
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'corretto'
+          distribution: 'temurin'
           java-version: '21'
           java-package: jdk
           server-id: central # Value of the distributionManagement/repository/id field of the pom.xml

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/utils/ContainerTestUtils.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/utils/ContainerTestUtils.java
@@ -39,8 +39,7 @@ public class ContainerTestUtils {
         .withServices(service);
   }
 
-  public static String awsServiceEndpoint(
-      LocalStackContainer awsContainer, LocalStackContainer.Service service) {
+  public static String awsServiceEndpoint(LocalStackContainer awsContainer, LocalStackContainer.Service service) {
     return awsContainer.getEndpointOverride(service).toString();
   }
 
@@ -49,19 +48,18 @@ public class ContainerTestUtils {
   }
 
   public static AmazonSQS sqsClient(LocalStackContainer awsContainer, String region) {
-    EndpointConfiguration endpointConfiguration =
-        new EndpointConfiguration(awsServiceEndpoint(awsContainer, SQS), region);
-    return AmazonSQSClientBuilder.standard()
-        .withEndpointConfiguration(endpointConfiguration)
-        .build();
+    EndpointConfiguration endpointConfiguration = new EndpointConfiguration(awsServiceEndpoint(awsContainer, SQS),
+        region);
+    return AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpointConfiguration).build();
   }
 
   public static AmazonS3 s3Client(LocalStackContainer awsContainer, String region) {
-    EndpointConfiguration endpointConfiguration =
-        new EndpointConfiguration(awsServiceEndpoint(awsContainer, S3), region);
+    EndpointConfiguration endpointConfiguration = new EndpointConfiguration(awsServiceEndpoint(awsContainer, S3),
+        region);
 
     // build with disableChunkedEncoding to be able to create empty files
-    return AmazonS3ClientBuilder.standard()
+    return AmazonS3ClientBuilder
+        .standard()
         .withEndpointConfiguration(endpointConfiguration)
         .withPathStyleAccessEnabled(true)
         .disableChunkedEncoding()

--- a/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/utils/ContainerTestUtils.java
+++ b/beekeeper-integration-tests/src/test/java/com/expediagroup/beekeeper/integration/utils/ContainerTestUtils.java
@@ -35,11 +35,12 @@ public class ContainerTestUtils {
   }
 
   public static LocalStackContainer awsContainer(LocalStackContainer.Service service) {
-    return new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0.0"))
+    return new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.7.0"))
         .withServices(service);
   }
 
-  public static String awsServiceEndpoint(LocalStackContainer awsContainer, LocalStackContainer.Service service) {
+  public static String awsServiceEndpoint(
+      LocalStackContainer awsContainer, LocalStackContainer.Service service) {
     return awsContainer.getEndpointOverride(service).toString();
   }
 
@@ -48,18 +49,19 @@ public class ContainerTestUtils {
   }
 
   public static AmazonSQS sqsClient(LocalStackContainer awsContainer, String region) {
-    EndpointConfiguration endpointConfiguration = new EndpointConfiguration(awsServiceEndpoint(awsContainer, SQS),
-        region);
-    return AmazonSQSClientBuilder.standard().withEndpointConfiguration(endpointConfiguration).build();
+    EndpointConfiguration endpointConfiguration =
+        new EndpointConfiguration(awsServiceEndpoint(awsContainer, SQS), region);
+    return AmazonSQSClientBuilder.standard()
+        .withEndpointConfiguration(endpointConfiguration)
+        .build();
   }
 
   public static AmazonS3 s3Client(LocalStackContainer awsContainer, String region) {
-    EndpointConfiguration endpointConfiguration = new EndpointConfiguration(awsServiceEndpoint(awsContainer, S3),
-        region);
+    EndpointConfiguration endpointConfiguration =
+        new EndpointConfiguration(awsServiceEndpoint(awsContainer, S3), region);
 
     // build with disableChunkedEncoding to be able to create empty files
-    return AmazonS3ClientBuilder
-        .standard()
+    return AmazonS3ClientBuilder.standard()
         .withEndpointConfiguration(endpointConfiguration)
         .withPathStyleAccessEnabled(true)
         .disableChunkedEncoding()

--- a/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/service/CleanupServiceSchedulerTest.java
+++ b/beekeeper-metadata-cleanup/src/test/java/com/expediagroup/beekeeper/metadata/cleanup/service/CleanupServiceSchedulerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2021 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
@@ -43,7 +42,6 @@ import com.expediagroup.beekeeper.cleanup.service.RepositoryCleanupScheduler;
 import com.expediagroup.beekeeper.core.error.BeekeeperException;
 
 @ExtendWith(SpringExtension.class)
-@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {
     "properties.scheduler-delay-ms=2000" })
 @ContextConfiguration(classes = { CleanupServiceScheduler.class, TestConfig.class },

--- a/beekeeper-path-cleanup/src/test/java/com/expediagroup/beekeeper/path/cleanup/service/CleanupServiceSchedulerTest.java
+++ b/beekeeper-path-cleanup/src/test/java/com/expediagroup/beekeeper/path/cleanup/service/CleanupServiceSchedulerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2019-2021 Expedia, Inc.
+ * Copyright (C) 2019-2026 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import java.time.Instant;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.annotation.DirtiesContext;
@@ -44,7 +43,6 @@ import com.expediagroup.beekeeper.cleanup.service.RepositoryCleanupScheduler;
 import com.expediagroup.beekeeper.core.error.BeekeeperException;
 
 @ExtendWith(SpringExtension.class)
-@ExtendWith(MockitoExtension.class)
 @TestPropertySource(properties = {
     "properties.scheduler-delay-ms=2000" })
 @ContextConfiguration(classes = { CleanupServiceScheduler.class, TestConfig.class },


### PR DESCRIPTION

 ## Summary                                                                                                                                                                                                                           
                                                                                                                                                                                                                                       
  - **LocalStack 3.0.0 → 3.7.0** in `ContainerTestUtils`: version 3.0.0 had a                                                                                                                                                          
    hardcoded 14s startup timeout for the hypercorn edge server, which regularly                                                                                                                                                       
    exceeded on Docker Desktop (actual startup ~18s), causing flaky integration                                                                                                                                                        
    test failures. 3.7.0 raises that timeout to 30s.                                                                                                                                                                                   
  - **Temurin JDK** replaces Corretto in all three GitHub Actions workflows                                                                                                                                                            
    (`build.yml`, `main.yml`, `release.yml`). As an open-source project, Temurin                                                                                                                                                       
    (Eclipse Adoptium) is the more appropriate default — it is vendor-neutral,                                                                                                                                                         
    TCK-certified, and widely used in OSS CI.

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.



