### PR TITLE
Fix add javax servlet api

### DIFF
--- a/beekeeper-cleanup/pom.xml
+++ b/beekeeper-cleanup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.6.7-SNAPSHOT</version>
+    <version>3.6.7.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-cleanup</artifactId>
@@ -72,6 +72,17 @@
         <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
+        </exclusion>
+        <!-- Old Tomcat Jasper implements javax.servlet.Servlet; with javax.servlet-api on the
+             runtime classpath, Tomcat 10.x would find JspServlet and fail to cast it to
+             jakarta.servlet.Servlet. Excluding it prevents the ClassCastException. -->
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-runtime</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/beekeeper-cleanup/pom.xml
+++ b/beekeeper-cleanup/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>beekeeper-parent</artifactId>
     <groupId>com.expediagroup</groupId>
-    <version>3.6.7.1-SNAPSHOT</version>
+    <version>3.6.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>beekeeper-cleanup</artifactId>
@@ -116,6 +116,17 @@
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+
+    <!-- hive-metastore 2.3.7 references javax.servlet.Filter internally at runtime;
+         Spring Boot 3.x uses Jakarta Servlet so javax.servlet is no longer on the classpath.
+         This runtime dependency satisfies Hive's classloading without affecting Spring's
+         Jakarta servlet stack. -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>runtime</scope>
     </dependency>
 
     <!-- aws -->

--- a/beekeeper-metadata-cleanup/pom.xml
+++ b/beekeeper-metadata-cleanup/pom.xml
@@ -95,6 +95,17 @@
       </exclusions>
     </dependency>
 
+    <!-- hive-metastore 2.3.7 references javax.servlet.Filter internally at runtime;
+         Spring Boot 3.x uses Jakarta Servlet so javax.servlet is no longer on the classpath.
+         This runtime dependency satisfies Hive's classloading without affecting Spring's
+         Jakarta servlet stack. -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- test -->
     <dependency>
       <groupId>org.awaitility</groupId>

--- a/beekeeper-path-cleanup/pom.xml
+++ b/beekeeper-path-cleanup/pom.xml
@@ -67,6 +67,16 @@
       <artifactId>guava</artifactId>
       <version>27.1-jre</version>
     </dependency>
+    <!-- hive-metastore 2.3.7 references javax.servlet.Filter internally at runtime;
+         Spring Boot 3.x uses Jakarta Servlet so javax.servlet is no longer on the classpath.
+         This runtime dependency satisfies Hive's classloading without affecting Spring's
+         Jakarta servlet stack. -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/beekeeper-scheduler-apiary/pom.xml
+++ b/beekeeper-scheduler-apiary/pom.xml
@@ -78,6 +78,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- hive-metastore 2.3.7 references javax.servlet.Filter internally at runtime;
+         Spring Boot 3.x uses Jakarta Servlet so javax.servlet is no longer on the classpath.
+         This runtime dependency satisfies Hive's classloading without affecting Spring's
+         Jakarta servlet stack. -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>

--- a/beekeeper-scheduler/pom.xml
+++ b/beekeeper-scheduler/pom.xml
@@ -72,6 +72,17 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <!-- Old Tomcat Jasper implements javax.servlet.Servlet; with javax.servlet-api on the
+             runtime classpath, Tomcat 10.x would find JspServlet and fail to cast it to
+             jakarta.servlet.Servlet. Excluding it prevents the ClassCastException. -->
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-compiler</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-runtime</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/beekeeper-scheduler/pom.xml
+++ b/beekeeper-scheduler/pom.xml
@@ -105,5 +105,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- hive-metastore 2.3.7 references javax.servlet.Filter internally at runtime;
+         Spring Boot 3.x uses Jakarta Servlet so javax.servlet is no longer on the classpath.
+         This runtime dependency satisfies Hive's classloading without affecting Spring's
+         Jakarta servlet stack. -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
After migrating to Spring Boot 3.x + Java 21, applications that use hive-metastore 2.3.7 fail at runtime

hive-metastore 2.3.7 was compiled against the old javax.servlet API. Spring Boot 3 / Tomcat 10 migrated to the jakarta.servlet namespace (Jakarta EE 9), so javax.servlet.Filter is no longer on the classpath.

Solution:

1. Add javax.servlet:javax.servlet-api:3.1.0 at runtime scope to all modules that have hive-metastore in their runtime classpath. The javax.* and jakarta.* namespaces are entirely separate packages and coexist safely — Spring Boot 3 uses jakarta.* for its own code while Hive's classloading finds javax.* from this dependency.                                                                                                                           
2. Exclude tomcat:jasper-compiler and tomcat:jasper-runtime from hive-metastore in the modules where they are pulled in transitively (beekeeper-cleanup,  beekeeper-scheduler). This prevents the ClassCastException caused by JspServlet implementing the old javax.servlet.Servlet interface. 


